### PR TITLE
[codex] Fix nested skill bundle scanning

### DIFF
--- a/server.js
+++ b/server.js
@@ -1481,6 +1481,20 @@ function skillFrontmatter(txt) {
   return { desc };
 }
 
+async function scanNestedSkillBundle(fp, source, label, out, disabled) {
+  const nestedRoot = path.join(fp, 'skills');
+  let nestedNames;
+  try { nestedNames = await fsp.readdir(nestedRoot, { withFileTypes: true }); } catch { return false; }
+  let hasSkills = false;
+  for (const x of nestedNames) {
+    if (!x.isDirectory() || x.name.startsWith('.')) continue;
+    try { await fsp.access(path.join(nestedRoot, x.name, 'SKILL.md')); hasSkills = true; break; } catch { /* not a skill */ }
+  }
+  if (!hasSkills) return false;
+  await scanSkillRoot(nestedRoot, source, `${label}/${path.basename(fp)}`, out, disabled);
+  return true;
+}
+
 async function scanSkillRoot(root, source, label, out, disabled = false) {
   let names;
   try { names = await fsp.readdir(root, { withFileTypes: true }); } catch { return; }
@@ -1524,6 +1538,7 @@ async function scanSkillRoot(root, source, label, out, disabled = false) {
         }
       }
     } catch {
+      if (await scanNestedSkillBundle(fp, source, label, out, disabled)) continue;
       item.residue = true;
       item.issues.push('缺 SKILL.md——不是有效 skill');
     }


### PR DESCRIPTION
## Summary
- detect repository-style skill bundles that store real skills under `skills/*/SKILL.md`
- scan those nested skills instead of marking the bundle root as a broken skill
- keep the existing missing-`SKILL.md` warning for ordinary broken skill directories

## Root cause
Skills X-ray scans one directory level under roots such as `~/.codex/skills`. A collection repo like `superpowers` has no root `SKILL.md`, but contains valid skills in `superpowers/skills/*/SKILL.md`, so FanBox showed the collection root as an invalid skill.

## Validation
- `node --check server.js`
- `npm run check:vendor-patch`
- temporary fixture verified a `superpowers/skills/demo-skill/SKILL.md` bundle is reported as `demo-skill`, while a normal missing-`SKILL.md` directory still reports the original warning