### PR TITLE
feat: 项目记忆增强——真会话标题 + 改名 + 全局项目记忆浏览器

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1430,27 +1430,14 @@ const shotTray = {
   dismiss() { clearTimeout(this.timer); if (this.el) { this.el.remove(); this.el = null; } },
 };
 
-// 项目记忆：这个文件夹里 AI 干过什么——历史会话考古，可展开改过的文件，可一键续上
-async function memoryPanel(dirPath) {
-  const old = $('.mem-overlay'); if (old) old.remove();
-  const ov = document.createElement('div');
-  ov.className = 'input-overlay mem-overlay';
-  ov.innerHTML = `<div class="input-dialog mem-dialog">
-    <div class="input-title">项目记忆 · ${escapeHtml(dirPath.replace(state.home, '~'))}</div>
-    <div class="mem-body"><div class="cmdk-loading">翻会话日志中…</div></div></div>`;
-  document.body.appendChild(ov);
-  // Esc 在标题编辑框里只取消编辑（input 自己处理），不关弹窗
-  const onKey = (ev) => { if (ev.key === 'Escape' && !(ev.target.closest && ev.target.closest('.mem-title-input'))) { ev.preventDefault(); close(); } };
-  const close = () => { ov.remove(); document.removeEventListener('keydown', onKey, true); };
-  ov.onclick = (ev) => { if (ev.target === ov) close(); };
-  document.addEventListener('keydown', onKey, true);
-  const d = await api('/api/project-memory?path=' + encodeURIComponent(dirPath));
-  const body = ov.querySelector('.mem-body');
-  if (!d.ok || !d.sessions.length) {
-    body.innerHTML = '<div class="empty-state">这个文件夹还没有 agent 会话记录<br><br><span class="usage-sub">在这里跑过 Claude Code / Codex 之后，历史会话会出现在这里</span></div>';
+// 会话列表渲染 + 事件绑定（✎改名 / ▶续上 / 点文件直达）——memoryPanel 和 allMemoryPanel 共用。
+// close：续上/点文件前关闭所在面板的回调；dirPath：这批会话所属目录
+function renderSessionList(container, dirPath, sessions, close) {
+  if (!sessions || !sessions.length) {
+    container.innerHTML = '<div class="empty-state">这个文件夹还没有 agent 会话记录<br><br><span class="usage-sub">在这里跑过 Claude Code / Codex 之后，历史会话会出现在这里</span></div>';
     return;
   }
-  body.innerHTML = d.sessions.map((s, i) => `
+  container.innerHTML = sessions.map((s, i) => `
     <div class="mem-sess">
       <div class="mem-head" data-i="${i}">
         <span class="mem-agent${s.agent === 'codex' ? ' codex' : ''}">${s.agent === 'codex' ? '>_' : 'C'}</span>
@@ -1461,7 +1448,7 @@ async function memoryPanel(dirPath) {
       <div class="mem-meta">${fmtTime(s.lastT)} · ${s.userMsgs} 条消息${s.files.length ? ` · 改了 ${s.files.length} 个文件` : ''}${s.skills.length ? ' · ' + s.skills.map((k) => `<i class="mem-skill">${escapeHtml(k)}</i>`).join(' ') : ''}</div>
       ${s.files.length ? `<div class="mem-files hidden">${s.files.map((f) => `<div class="mem-file" data-p="${escapeHtml(f)}" title="${escapeHtml(f)}">${escapeHtml(f.startsWith(dirPath + '/') ? f.slice(dirPath.length + 1) : f.replace(state.home, '~'))}</div>`).join('')}</div>` : ''}
     </div>`).join('');
-  body.querySelectorAll('.mem-head').forEach((h) => {
+  container.querySelectorAll('.mem-head').forEach((h) => {
     h.onclick = (ev) => {
       if (ev.target.closest('.mem-resume') || ev.target.closest('.mem-edit') || ev.target.closest('.mem-title-input')) return;
       const files = h.parentElement.querySelector('.mem-files');
@@ -1469,9 +1456,9 @@ async function memoryPanel(dirPath) {
     };
   });
   // 改标题：标题原地变输入框，Enter 保存（append custom-title 行）、Esc/失焦取消
-  body.querySelectorAll('.mem-edit').forEach((b) => {
+  container.querySelectorAll('.mem-edit').forEach((b) => {
     b.onclick = () => {
-      const s = d.sessions[Number(b.dataset.i)];
+      const s = sessions[Number(b.dataset.i)];
       const titleEl = b.parentElement.querySelector('.mem-title');
       const input = document.createElement('input');
       input.className = 'mem-title-input';
@@ -1499,23 +1486,85 @@ async function memoryPanel(dirPath) {
       };
     };
   });
-  body.querySelectorAll('.mem-resume').forEach((b) => {
+  container.querySelectorAll('.mem-resume').forEach((b) => {
     b.onclick = () => {
-      const s = d.sessions[Number(b.dataset.i)];
+      const s = sessions[Number(b.dataset.i)];
       const cmd = s.agent === 'codex' ? `codex resume ${s.id}` : `claude --dangerously-skip-permissions --resume ${s.id}`;
-      close();
+      if (close) close();
       term.runInDir(dirPath, cmd, '已在终端续上会话');
     };
   });
-  body.querySelectorAll('.mem-file').forEach((f) => {
+  container.querySelectorAll('.mem-file').forEach((f) => {
     f.onclick = async () => {
       const p = f.dataset.p;
-      close();
+      if (close) close();
       await navigate(dirOf(p));
       const e = state.entries.find((x) => x.path === p);
       if (e) { state.selected = p; openPreview(e); renderFiles(); }
     };
   });
+}
+
+// 项目记忆：这个文件夹里 AI 干过什么——历史会话考古，可展开改过的文件，可一键续上
+async function memoryPanel(dirPath) {
+  const old = $('.mem-overlay'); if (old) old.remove();
+  const ov = document.createElement('div');
+  ov.className = 'input-overlay mem-overlay';
+  ov.innerHTML = `<div class="input-dialog mem-dialog">
+    <div class="input-title">项目记忆 · ${escapeHtml(dirPath.replace(state.home, '~'))}</div>
+    <div class="mem-body"><div class="cmdk-loading">翻会话日志中…</div></div></div>`;
+  document.body.appendChild(ov);
+  // Esc 在标题编辑框里只取消编辑（input 自己处理），不关弹窗
+  const onKey = (ev) => { if (ev.key === 'Escape' && !(ev.target.closest && ev.target.closest('.mem-title-input'))) { ev.preventDefault(); close(); } };
+  const close = () => { ov.remove(); document.removeEventListener('keydown', onKey, true); };
+  ov.onclick = (ev) => { if (ev.target === ov) close(); };
+  document.addEventListener('keydown', onKey, true);
+  const d = await api('/api/project-memory?path=' + encodeURIComponent(dirPath));
+  renderSessionList(ov.querySelector('.mem-body'), dirPath, d.ok ? d.sessions : [], close);
+}
+
+// 全局项目记忆：左栏全部 agent 项目（顺序同侧栏 / 按最近活跃排），选一个右栏展示该目录会话
+async function allMemoryPanel() {
+  const old = $('.mem-overlay'); if (old) old.remove();
+  const ov = document.createElement('div');
+  ov.className = 'input-overlay mem-overlay';
+  ov.innerHTML = `<div class="input-dialog allmem-dialog">
+    <div class="input-title">项目记忆 · 全部 Agent 项目</div>
+    <div class="allmem-body">
+      <div class="allmem-projs"><div class="cmdk-loading">扫描项目中…</div></div>
+      <div class="allmem-sessions mem-body"><div class="empty-state usage-sub">选左侧一个项目查看它的会话</div></div>
+    </div></div>`;
+  document.body.appendChild(ov);
+  const onKey = (ev) => { if (ev.key === 'Escape' && !(ev.target.closest && ev.target.closest('.mem-title-input'))) { ev.preventDefault(); close(); } };
+  const close = () => { ov.remove(); document.removeEventListener('keydown', onKey, true); };
+  ov.onclick = (ev) => { if (ev.target === ov) close(); };
+  document.addEventListener('keydown', onKey, true);
+
+  const projsEl = ov.querySelector('.allmem-projs');
+  const sessEl = ov.querySelector('.allmem-sessions');
+  const data = await api('/api/agent-projects').catch(() => null);
+  const projects = (data && data.projects) || [];
+  if (!projects.length) {
+    projsEl.innerHTML = '<div class="empty-state usage-sub">用 Claude Code / Codex 跑过的项目会出现在这里</div>';
+    sessEl.innerHTML = '';
+    return;
+  }
+  const selectProj = async (i) => {
+    projsEl.querySelectorAll('.allmem-proj').forEach((el, j) => el.classList.toggle('on', j === i));
+    sessEl.innerHTML = '<div class="cmdk-loading">翻会话日志中…</div>';
+    const dirPath = projects[i].path;
+    const d = await api('/api/project-memory?path=' + encodeURIComponent(dirPath)).catch(() => null);
+    renderSessionList(sessEl, dirPath, d && d.ok ? d.sessions : [], close);
+  };
+  projsEl.innerHTML = projects.map((pj, i) => `
+    <div class="allmem-proj" data-i="${i}" title="${escapeHtml(pj.path)}">
+      <span class="allmem-proj-name">${escapeHtml(pj.name)}</span>
+      <span class="allmem-proj-meta">${pj.agents.map((a) => `<i class="agent-dot ${a}" title="${a}"></i>`).join('')}${agoShort(pj.lastActive)}</span>
+    </div>`).join('');
+  projsEl.querySelectorAll('.allmem-proj').forEach((el) => {
+    el.onclick = () => selectProj(Number(el.dataset.i));
+  });
+  selectProj(0); // 默认选第一个（最近活跃的）
 }
 
 // AI 整理：一键在内嵌终端拉起交互式 agent（claude/codex）对话式整理。
@@ -2002,6 +2051,7 @@ function bindEvents() {
   usagePanel.bind();
   shotTray.init();
   $('#skills-entry').onclick = () => skillsView.show();
+  $('#allmem-entry').onclick = (ev) => { ev.stopPropagation(); allMemoryPanel(); };
   $('#term-newtab').onclick = () => term.newTab();
   $('#term-max').onclick = () => term.toggleMax();
   $('#term-dock').onclick = () => term.setDock(term.dock === 'bottom' ? 'right' : 'bottom');

--- a/public/app.js
+++ b/public/app.js
@@ -1439,7 +1439,8 @@ async function memoryPanel(dirPath) {
     <div class="input-title">项目记忆 · ${escapeHtml(dirPath.replace(state.home, '~'))}</div>
     <div class="mem-body"><div class="cmdk-loading">翻会话日志中…</div></div></div>`;
   document.body.appendChild(ov);
-  const onKey = (ev) => { if (ev.key === 'Escape') { ev.preventDefault(); close(); } };
+  // Esc 在标题编辑框里只取消编辑（input 自己处理），不关弹窗
+  const onKey = (ev) => { if (ev.key === 'Escape' && !(ev.target.closest && ev.target.closest('.mem-title-input'))) { ev.preventDefault(); close(); } };
   const close = () => { ov.remove(); document.removeEventListener('keydown', onKey, true); };
   ov.onclick = (ev) => { if (ev.target === ov) close(); };
   document.addEventListener('keydown', onKey, true);
@@ -1454,6 +1455,7 @@ async function memoryPanel(dirPath) {
       <div class="mem-head" data-i="${i}">
         <span class="mem-agent${s.agent === 'codex' ? ' codex' : ''}">${s.agent === 'codex' ? '>_' : 'C'}</span>
         <span class="mem-title">${escapeHtml(s.title || '（无标题会话）')}</span>
+        ${s.agent === 'claude' ? `<button class="ghost-btn mem-edit" data-i="${i}" title="改标题（Claude Code 里也会同步显示）">✎</button>` : ''}
         <button class="ghost-btn mem-resume" data-i="${i}" title="在内嵌终端里接上这段会话的上下文继续">▶ 续上</button>
       </div>
       <div class="mem-meta">${fmtTime(s.lastT)} · ${s.userMsgs} 条消息${s.files.length ? ` · 改了 ${s.files.length} 个文件` : ''}${s.skills.length ? ' · ' + s.skills.map((k) => `<i class="mem-skill">${escapeHtml(k)}</i>`).join(' ') : ''}</div>
@@ -1461,9 +1463,40 @@ async function memoryPanel(dirPath) {
     </div>`).join('');
   body.querySelectorAll('.mem-head').forEach((h) => {
     h.onclick = (ev) => {
-      if (ev.target.closest('.mem-resume')) return;
+      if (ev.target.closest('.mem-resume') || ev.target.closest('.mem-edit') || ev.target.closest('.mem-title-input')) return;
       const files = h.parentElement.querySelector('.mem-files');
       if (files) files.classList.toggle('hidden');
+    };
+  });
+  // 改标题：标题原地变输入框，Enter 保存（append custom-title 行）、Esc/失焦取消
+  body.querySelectorAll('.mem-edit').forEach((b) => {
+    b.onclick = () => {
+      const s = d.sessions[Number(b.dataset.i)];
+      const titleEl = b.parentElement.querySelector('.mem-title');
+      const input = document.createElement('input');
+      input.className = 'mem-title-input';
+      input.value = s.title || '';
+      titleEl.replaceWith(input);
+      input.focus(); input.select();
+      let done = false, saving = false;
+      const restore = (text) => {
+        if (done) return; done = true;
+        const span = document.createElement('span');
+        span.className = 'mem-title';
+        span.textContent = text || '（无标题会话）';
+        input.replaceWith(span);
+      };
+      input.onblur = () => { if (!saving) restore(s.title); };
+      input.onkeydown = async (ke) => {
+        if (ke.key === 'Escape') { restore(s.title); return; }
+        if (ke.key !== 'Enter') return;
+        const v = input.value.trim();
+        if (!v || v === s.title) { restore(s.title); return; }
+        saving = true;
+        const r = await apiPost('/api/session-title', { path: dirPath, id: s.id, title: v });
+        if (r.ok) { s.title = r.title; restore(s.title); toast('标题已更新'); }
+        else { saving = false; restore(s.title); toast(r.error || '改标题失败', true); }
+      };
     };
   });
   body.querySelectorAll('.mem-resume').forEach((b) => {

--- a/public/i18n-dict.js
+++ b/public/i18n-dict.js
@@ -190,7 +190,6 @@ window.FANBOX_DICT = {
 
   // ---------- 项目记忆面板 ----------
   '翻会话日志中…': 'Digging through session logs…',
-  '项目记忆 · 浏览全部项目的会话记录': 'Project memory · browse sessions across all projects',
   '项目记忆 · 全部 Agent 项目': 'Project memory · All agent projects',
   '扫描项目中…': 'Scanning projects…',
   '选左侧一个项目查看它的会话': 'Pick a project on the left to see its sessions',

--- a/public/i18n-dict.js
+++ b/public/i18n-dict.js
@@ -196,6 +196,12 @@ window.FANBOX_DICT = {
   '在内嵌终端里接上这段会话的上下文继续': "Resume this session's context in the embedded terminal",
   '▶ 续上': '▶ Resume',
   '已在终端续上会话': 'Session resumed in terminal',
+  '改标题（Claude Code 里也会同步显示）': 'Rename (also shows up in Claude Code)',
+  '标题已更新': 'Title updated',
+  '改标题失败': 'Failed to rename',
+  '标题不能为空': 'Title cannot be empty',
+  '无效会话 id': 'Invalid session id',
+  '找不到这个会话的日志文件': "Can't find this session's log file",
 
   // ---------- AI 整理（终端交互式）----------
   '没找到 claude / codex 命令——AI 整理需要装其中一个 CLI': 'claude / codex command not found — AI organize needs one of these CLIs installed',

--- a/public/i18n-dict.js
+++ b/public/i18n-dict.js
@@ -190,6 +190,10 @@ window.FANBOX_DICT = {
 
   // ---------- 项目记忆面板 ----------
   '翻会话日志中…': 'Digging through session logs…',
+  '项目记忆 · 浏览全部项目的会话记录': 'Project memory · browse sessions across all projects',
+  '项目记忆 · 全部 Agent 项目': 'Project memory · All agent projects',
+  '扫描项目中…': 'Scanning projects…',
+  '选左侧一个项目查看它的会话': 'Pick a project on the left to see its sessions',
   '这个文件夹还没有 agent 会话记录': 'No agent sessions in this folder yet',
   '在这里跑过 Claude Code / Codex 之后，历史会话会出现在这里': 'Run Claude Code / Codex here and past sessions will appear',
   '（无标题会话）': '(untitled session)',

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
       </nav>
 
       <nav class="nav-section">
-        <div class="nav-title" title="最近被 Claude Code / Codex 处理过的项目，自动从两者的本机会话记录扫出来"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg> Agent 项目<button id="allmem-entry" class="navtitle-act" title="项目记忆 · 浏览全部项目的会话记录"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg></button></div>
+        <div class="nav-title" title="最近被 Claude Code / Codex 处理过的项目，自动从两者的本机会话记录扫出来"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg> Agent 项目<button id="allmem-entry" class="navtitle-act"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg></button></div>
         <ul id="agent-projects-list" class="nav-list"></ul>
       </nav>
 

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
       </nav>
 
       <nav class="nav-section">
-        <div class="nav-title" title="最近被 Claude Code / Codex 处理过的项目，自动从两者的本机会话记录扫出来"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg> Agent 项目</div>
+        <div class="nav-title" title="最近被 Claude Code / Codex 处理过的项目，自动从两者的本机会话记录扫出来"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg> Agent 项目<button id="allmem-entry" class="navtitle-act" title="项目记忆 · 浏览全部项目的会话记录"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><polyline points="12 7 12 12 15 14"/></svg></button></div>
         <ul id="agent-projects-list" class="nav-list"></ul>
       </nav>
 

--- a/public/style.css
+++ b/public/style.css
@@ -557,7 +557,7 @@ kbd {
 
 /* 项目记忆 */
 .sb-links { display: flex; gap: 14px; }
-.mem-dialog { width: 680px; max-width: 94vw; }
+.input-dialog.mem-dialog { width: 680px; max-width: 94vw; } /* 双类提特异性：否则被后面的 .input-dialog{width:420px} 压窄 */
 .mem-body { max-height: 68vh; overflow-y: auto; margin-top: 8px; }
 .mem-sess { padding: 9px 6px; border-bottom: 1px solid var(--border); }
 .mem-sess:last-child { border-bottom: none; }
@@ -574,6 +574,21 @@ kbd {
 .mem-files { margin: 6px 0 0 28px; }
 .mem-file { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); padding: 2px 6px; border-radius: 4px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .mem-file:hover { background: var(--bg-3); color: var(--text); }
+
+/* 全局项目记忆：标题栏入口按钮 + 双栏面板 */
+.navtitle-act { margin-left: auto; display: inline-flex; align-items: center; justify-content: center; padding: 2px; border: none; background: none; color: var(--text-faint); cursor: pointer; border-radius: 5px; }
+.navtitle-act:hover { color: var(--accent); background: var(--accent-soft); }
+/* 双类提高特异性：基础 .input-dialog{width:420px} 在表里排在后面，单类会被它覆盖 */
+.input-dialog.allmem-dialog { width: 900px; max-width: 96vw; }
+.allmem-body { display: flex; gap: 12px; margin-top: 8px; height: 68vh; }
+.allmem-projs { flex: 0 0 36%; min-width: 150px; max-width: 240px; overflow-y: auto; border-right: 1px solid var(--border); padding-right: 6px; }
+.allmem-proj { padding: 7px 9px; border-radius: 7px; cursor: pointer; display: flex; flex-direction: column; gap: 3px; }
+.allmem-proj:hover { background: var(--bg-3); }
+.allmem-proj.on { background: var(--accent-soft); }
+.allmem-proj-name { font-size: 12.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.allmem-proj.on .allmem-proj-name { color: var(--accent); }
+.allmem-proj-meta { font-size: 10.5px; color: var(--text-faint); display: flex; align-items: center; gap: 4px; }
+.allmem-sessions { flex: 1; min-width: 0; overflow-y: auto; max-height: none; margin-top: 0; }
 
 /* 磁盘占用透视 */
 .disk-dialog { width: 540px; max-width: 92vw; }

--- a/public/style.css
+++ b/public/style.css
@@ -566,6 +566,9 @@ kbd {
 .mem-agent.codex { background: var(--bg-3); color: var(--text-dim); }
 .mem-title { flex: 1; font-size: 12.5px; line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .mem-resume { flex: none; font-size: 11px; padding: 3px 8px; }
+.mem-edit { flex: none; font-size: 11px; padding: 3px 7px; }
+.mem-title-input { flex: 1; min-width: 0; font: inherit; font-size: 12.5px; line-height: 1.45; background: var(--bg); color: var(--text); border: 1px solid var(--accent); border-radius: 6px; padding: 2px 7px; }
+.mem-title-input:focus { outline: none; }
 .mem-meta { font-size: 11px; color: var(--text-faint); margin: 4px 0 0 28px; }
 .mem-skill { font-style: normal; font-family: var(--font-mono); font-size: 10px; padding: 1px 5px; border-radius: 4px; background: var(--accent-soft); color: var(--accent); }
 .mem-files { margin: 6px 0 0 28px; }

--- a/server.js
+++ b/server.js
@@ -658,6 +658,7 @@ async function parseClaudeSession(fp, st) {
   if (hit && hit.size === st.size && hit.mtimeMs === st.mtimeMs) return hit.sess;
   const sess = { id: path.basename(fp, '.jsonl'), agent: 'claude', title: '', firstT: 0, lastT: st.mtimeMs, userMsgs: 0, files: [], skills: [] };
   const filesSet = new Set(), skillsSet = new Set();
+  let customTitle = '', aiTitle = ''; // Claude Code 落盘的真标题行，重复出现以最后一条为准
   // 流式逐行，廉价字符串预判后才 JSON.parse——大会话文件也不整读进内存
   const stream = fs.createReadStream(fp, { encoding: 'utf8' });
   let rest = '';
@@ -665,6 +666,13 @@ async function parseClaudeSession(fp, st) {
     if (!sess.firstT) {
       const m = line.match(/"timestamp":"([^"]+)"/);
       if (m) sess.firstT = Date.parse(m[1]) || 0;
+    }
+    if (line.includes('"type":"custom-title"') || line.includes('"type":"ai-title"')) {
+      try {
+        const d = JSON.parse(line);
+        if (d.type === 'custom-title' && d.customTitle) customTitle = String(d.customTitle);
+        else if (d.type === 'ai-title' && d.aiTitle) aiTitle = String(d.aiTitle);
+      } catch { /* */ }
     }
     if (line.includes('"type":"user"') && !line.includes('"isMeta":true') && !line.includes('"tool_use_id"')) {
       sess.userMsgs++;
@@ -706,6 +714,8 @@ async function parseClaudeSession(fp, st) {
     while ((idx = rest.indexOf('\n')) !== -1) { handleLine(rest.slice(0, idx)); rest = rest.slice(idx + 1); }
   }
   if (rest.trim()) handleLine(rest);
+  // 标题优先级：用户手改 > AI 起的 > 首条用户消息兜底
+  sess.title = (customTitle || aiTitle || sess.title).slice(0, 160);
   sess.files = [...filesSet].slice(0, 80);
   sess.skills = [...skillsSet].slice(0, 20);
   projMemCache.set(fp, { size: st.size, mtimeMs: st.mtimeMs, sess });
@@ -779,6 +789,30 @@ async function projectMemory(p) {
   sessions.sort((a, b) => (b.title ? 1 : 0) - (a.title ? 1 : 0) || b.lastT - a.lastT);
   sessions.sort((a, b) => b.lastT - a.lastT);
   return { ok: true, cwd, sessions: sessions.filter((s) => s.title || s.files.length).slice(0, 40) };
+}
+
+// 改会话标题：复用 Claude Code 自己的 custom-title 机制——往会话 jsonl 末尾 append 一行，
+// 重复出现以最后一条为准，所以不用重写文件，对运行中的会话也安全；claude --resume 选择器同步可见
+async function setSessionTitle(b) {
+  const id = String(b.id || '');
+  if (!/^[0-9a-f][0-9a-f-]{7,}$/i.test(id)) return { ok: false, error: '无效会话 id' };
+  const title = String(b.title || '').replace(/\s+/g, ' ').trim().slice(0, 160);
+  if (!title) return { ok: false, error: '标题不能为空' };
+  const fp = path.join(CLAUDE_PROJ, mungeClaudeDir(resolvePath(b.path)), id + '.jsonl');
+  let st;
+  try { st = await fsp.stat(fp); } catch { return { ok: false, error: '找不到这个会话的日志文件' }; }
+  // 文件末尾若没换行（异常截断），补一个再 append，免得粘到上一行把两行都毁了
+  let needNL = false;
+  if (st.size > 0) {
+    const fh = await fsp.open(fp, 'r');
+    try {
+      const buf = Buffer.alloc(1);
+      await fh.read(buf, 0, 1, st.size - 1);
+      needNL = buf[0] !== 0x0a;
+    } finally { await fh.close(); }
+  }
+  await fsp.appendFile(fp, (needNL ? '\n' : '') + JSON.stringify({ type: 'custom-title', customTitle: title, sessionId: id }) + '\n');
+  return { ok: true, title };
 }
 
 // ---------- 磁盘占用透视：算清当前目录每个子项的真实占用 ----------
@@ -1961,6 +1995,9 @@ const server = http.createServer(async (req, res) => {
     }
     if (p === '/api/project-memory') {
       return sendJSON(res, 200, await projectMemory(url.searchParams.get('path')));
+    }
+    if (p === '/api/session-title' && req.method === 'POST') {
+      return sendJSON(res, 200, await setSessionTitle(await readBody(req)));
     }
     if (p === '/api/lang' && req.method === 'POST') {
       const b = await readBody(req);

--- a/server.js
+++ b/server.js
@@ -1571,7 +1571,7 @@ async function agentProjects() {
   const sorted = [...map.entries()].sort((a, b) => b[1].lastActive - a[1].lastActive);
   const projects = [];
   for (const [cwd, info] of sorted) {
-    if (projects.length >= 12) break;
+    if (projects.length >= 50) break; // 侧栏只取前 8，全局记忆浏览器要看全部——上限放到 50 兜底
     try { if (!(await fsp.stat(cwd)).isDirectory()) continue; } catch { continue; }
     projects.push({ path: cwd, name: path.basename(cwd), agents: [...info.agents], lastActive: info.lastActive });
   }


### PR DESCRIPTION
## 这个 PR 做了什么

两个围绕「项目记忆」的增强（强耦合，放在一起）：

### 1. 真会话标题 + 原地改名
- 历史会话标题不再用「首条用户消息截断」，改为读 Claude Code 落盘的标题行：手改的 `custom-title` > AI 起的 `ai-title` > 首条消息兜底
- Claude 会话标题旁加 ✎，原地改名走 `POST /api/session-title`——往会话 jsonl 末尾 append 一行 `custom-title`（不重写文件，对运行中会话安全），改完 `claude --resume` 选择器里同步可见
- Codex 无标题机制，保持只读

### 2. 全局项目记忆浏览器
- 侧栏新增一个入口，一处看遍所有 agent 项目的会话，不用逐个项目点进去

## 改动范围
- `public/app.js`、`server.js`、`public/i18n-dict.js`、`public/index.html`、`public/style.css`
- 基于当前 master（v1.8.2），未改 CHANGELOG（留给你统一维护）

🤖 Generated with [Claude Code](https://claude.com/claude-code)