### PR TITLE
feat(终端): 支持自定义终端字体，解决 Starship 等工具图标显示为乱码的问题

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -192,6 +192,7 @@ const state = {
   sidebarCollapsed: localStorage.getItem('fb_sidebar_collapsed') === '1',
   sidebarW: Math.min(420, Math.max(190, Number(localStorage.getItem('fb_sidebar_w')) || 248)),
   muted: localStorage.getItem('fb_muted') === '1', // WOW4 提示音静音开关
+  termFont: '', // 终端字体（从 ~/.fanbox/config.json 读取，为空则用 CSS 变量 --font-mono）
   changeLog: [], // 本会话 agent 改过的文件（跨所有监听目录，按文件去重、最新置顶），供「变更」面板回看
   changeTimeline: [], // 每一次写入事件（不去重，带时间戳），供「会话回放」拖时间轴重现
 };
@@ -1582,6 +1583,12 @@ async function loadFavorites() {
   state.recentOpened = data.recentOpened || [];
   renderFavs();
 }
+async function loadTermFont() {
+  try {
+    const r = await api('/api/config?key=termFont');
+    if (r && r.value) state.termFont = r.value;
+  } catch { /* config.json 不存在或没配 termFont，保持为空，用 CSS 变量兜底 */ }
+}
 function renderFavs() {
   const ul = $('#favs-list');
   ul.innerHTML = '';
@@ -2274,7 +2281,7 @@ const term = {
     host.classList.add('show'); // 先可见再 open/fit：display:none 下 fit 量不出尺寸，PTY 会以 80 列出生
     const FitCtor = window.FitAddon ? (window.FitAddon.FitAddon || window.FitAddon) : null;
     const xterm = new window.Terminal({
-      fontFamily: getComputedStyle(document.documentElement).getPropertyValue('--font-mono').trim() || 'monospace',
+      fontFamily: state.termFont || getComputedStyle(document.documentElement).getPropertyValue('--font-mono').trim() || 'monospace',
       fontSize: 13, lineHeight: 1.2, cursorBlink: true, theme: this.theme(), scrollback: 5000,
       allowProposedApi: true, // unicode11 宽度 API 需要
       // agent 常输出按深色终端设计的 256 色/真彩（如淡蓝路径），在浅色皮肤上几乎隐形；
@@ -3488,6 +3495,7 @@ async function init() {
   document.querySelectorAll('#theme-switch .theme-seg button').forEach((b) => { b.onclick = () => applyTheme(b.dataset.skin); });
   await loadRoots();
   await loadFavorites();
+  loadTermFont(); // 终端字体从 ~/.fanbox/config.json 读取，不阻塞 init
   loadAgentProjects();
   setInterval(loadAgentProjects, 120000); // agent 项目入口保持新鲜（服务端有 60s 缓存，开销很小）
   await navigate(state.home, false);

--- a/server.js
+++ b/server.js
@@ -1892,6 +1892,23 @@ const server = http.createServer(async (req, res) => {
       await updateConfig((c) => { c.lang = lang; });
       return sendJSON(res, 200, { ok: true, lang });
     }
+    // 终端字体配置：前端只读 termFont，写入走相同 POST 端点
+    if (p === '/api/config') {
+      if (req.method === 'GET') {
+        const key = qp.get('key');
+        const cfg = await readConfig();
+        return sendJSON(res, 200, { key, value: cfg[key] || null });
+      }
+      if (req.method === 'POST') {
+        const b = await readBody(req);
+        if (!b.key || typeof b.key !== 'string') return sendJSON(res, 400, { error: '缺少 key' });
+        const key = b.key;
+        // 白名单：只允许透传已知的 UI 配置字段，config.json 里还有 recent/favorites 等内部数据
+        if (key !== 'termFont') return sendJSON(res, 400, { error: '不支持的配置项' });
+        const cfg = await updateConfig((c) => { c[key] = String(b.value || ''); });
+        return sendJSON(res, 200, { ok: true, key, value: cfg[key] || '' });
+      }
+    }
     if (p === '/api/organize/launch' && req.method === 'POST') {
       return sendJSON(res, 200, await organizeLaunch(await readBody(req)));
     }


### PR DESCRIPTION
## 背景

FanBox 内置终端硬编码使用系统等宽字体，不支持 Nerd Font 图标字形的显示。使用 Starship 等需要 Powerline/Nerd Font 字形支持的终端工具时，图标全部显示为乱码。

Closes #15

## 改动

- **server.js**: 新增 GET/POST /api/config 端点，白名单只允许透传 termFont，复用已有的 readConfig()/updateConfig() 原子写入
- **app.js**: 新增 loadTermFont() 在 init 阶段异步读取 ~/.fanbox/config.json 中的 termFont，缓存到 state.termFont；term.newTab() 创建 xterm 时优先使用配置字体，未配置则回退到 CSS 变量 --font-mono 兜底

## 使用方式

在 ~/.fanbox/config.json 中添加：

```json
{
  "termFont": "MesloLGS NF"
}
```

重启 FanBox 后终端即使用指定字体。不配置或删除该字段则保持原有行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)