### PR TITLE
feat(mac): add Intel Mac (x64) dmg alongside arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ## [Unreleased]
 
+### Added
+- Intel Mac (x64) 桌面版支持：mac.target 恢复同时打 arm64 + x64 两个 dmg。node-pty 自带 N-API prebuilds（darwin-arm64、darwin-x64），ABI 跨 Node/Electron 稳定，运行时按 `process.arch` 自动挑对应版本，无需为 x64 重新编译
+
 ## [1.9.1] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ The UI was designed with [huashu-design](https://github.com/alchaincyf/huashu-de
 
 ### 桌面版（推荐）/ Desktop (recommended)
 
-从 [**Releases**](https://github.com/alchaincyf/fanbox/releases/latest) 下载最新 `.dmg`，拖进「应用程序」即可。Apple Silicon (arm64) 原生。
+从 [**Releases**](https://github.com/alchaincyf/fanbox/releases/latest) 下载最新 `.dmg`，拖进「应用程序」即可。Apple Silicon (arm64) 与 Intel (x64) 原生。
 
-Download the latest `.dmg` from [**Releases**](https://github.com/alchaincyf/fanbox/releases/latest) and drag it into Applications. Native Apple Silicon (arm64).
+Download the latest `.dmg` from [**Releases**](https://github.com/alchaincyf/fanbox/releases/latest) and drag it into Applications. Native Apple Silicon (arm64) and Intel (x64).
 
 > 已用 Apple Development 证书签名 + hardened runtime。首次打开若提示「未验证的开发者」：**右键 → 打开 → 确认**即可。  
 > Signed with an Apple Development certificate + hardened runtime. If macOS warns about an unverified developer on first launch: **right-click → Open → confirm**.
@@ -239,7 +239,7 @@ Every frontend dependency is vendored locally (`public/vendor/`) — that's what
 | 桌面壳 / Desktop shell | Electron 33 + node-pty（asarUnpack 原生模块）<br>Electron 33 + node-pty (asarUnpack native module) |
 | 终端 / Terminal | xterm.js + WebGL + unicode11 |
 | 编辑器 / Editors | Monaco（代码）+ Milkdown Crepe（Markdown）<br>Monaco (code) + Milkdown Crepe (Markdown) |
-| 打包 / Packaging | electron-builder → 签名 arm64 .dmg<br>electron-builder → signed arm64 .dmg |
+| 打包 / Packaging | electron-builder → 签名 arm64 + x64 .dmg<br>electron-builder → signed arm64 + x64 .dmg |
 
 <details>
 <summary>项目结构 / Project layout</summary>

--- a/package.json
+++ b/package.json
@@ -36,10 +36,15 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
       "target": [
         {
           "target": "dmg",
           "arch": "arm64"
+        },
+        {
+          "target": "dmg",
+          "arch": "x64"
         }
       ]
     },


### PR DESCRIPTION
## Summary
 mac.target 同时打 arm64 + x64 两个 dmg，让 Intel Mac 用户能装。

## Changes
- `package.json`: mac.target 加 x64 target；加 `artifactName: ${productName}-${version}-${arch}.${ext}` 让两个 dmg 都带 -arch 后缀
- `README.md`: 安装/架构描述更新（zh + en）
- `CHANGELOG.md`: [Unreleased] 加 Added 条目

## Why not `npmRebuild: true`
node-pty 自带 N-API prebuilds（darwin-arm64、darwin-x64），N-API ABI 跨 Node/Electron 稳定，runtime 按 `process.arch` 自动挑对应版本，无需为 x64 重新编译。这是 v1.8.3 时期验证过的成功路径，无需改动。

## Verification (arm64 主机上)
- `npm run dist` 退出 0
- x64 dmg 主程序：`Mach-O 64-bit executable x86_64` ✓
- x64 dmg 内 `prebuilds/darwin-x64/pty.node`：`Mach-O 64-bit bundle x86_64` ✓
- arm64 dmg 同样正确
- 文件命名：`FanBox-1.9.1-arm64.dmg` + `FanBox-1.9.1-x64.dmg`

## Not yet verified
Intel Mac 真机装跑——维护者只有 arm64 机器，需要 Intel Mac 用户真机验证：
1. 安装后能开
2. 终端能起（node-pty 加载）
3. 文件区/预览/编辑器正常

#8 