### PR TITLE
feat: Windows 桌面版支持

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -39,19 +39,29 @@ function saveBounds() {
 
 function createWindow() {
   const b = loadBounds();
-  win = new BrowserWindow({
+  const isWin = process.platform === 'win32';
+  const opts = {
     width: b.width, height: b.height, x: b.x, y: b.y,
     minWidth: 920, minHeight: 600,
-    titleBarStyle: 'hiddenInset',
     backgroundColor: '#0b0c0a',
-    vibrancy: 'sidebar',
-    visualEffectState: 'active',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
-  });
+  };
+  if (isWin) {
+    // Windows：隐藏标题栏，用自定义最小化/最大化/关闭按钮
+    opts.titleBarStyle = 'hidden';
+    opts.titleBarOverlay = { color: '#0b0c0a', symbolColor: '#8a8a8a', height: 36 };
+    opts.icon = path.join(__dirname, '..', 'build', 'icon.ico');
+  } else {
+    // macOS：隐藏标题栏 + 毛玻璃
+    opts.titleBarStyle = 'hiddenInset';
+    opts.vibrancy = 'sidebar';
+    opts.visualEffectState = 'active';
+  }
+  win = new BrowserWindow(opts);
   // 拖动/缩放后防抖记忆，关窗再存一次兜底
   let bt = null;
   const remember = () => { clearTimeout(bt); bt = setTimeout(saveBounds, 400); };
@@ -92,23 +102,32 @@ app.whenReady().then(() => {
 
 // ---------- 截图直通车：监听系统截屏落盘，新截图推给渲染层浮出直通卡 ----------
 function screenshotDir() {
-  try {
-    const out = require('child_process').execSync('defaults read com.apple.screencapture location 2>/dev/null', { encoding: 'utf8' }).trim();
-    if (out) return out.startsWith('~') ? path.join(os.homedir(), out.slice(1)) : out;
-  } catch { /* 未自定义 → 默认桌面 */ }
+  if (process.platform === 'darwin') {
+    try {
+      const out = require('child_process').execSync('defaults read com.apple.screencapture location 2>/dev/null', { encoding: 'utf8' }).trim();
+      if (out) return out.startsWith('~') ? path.join(os.homedir(), out.slice(1)) : out;
+    } catch { /* 未自定义 → 默认桌面 */ }
+    return path.join(os.homedir(), 'Desktop');
+  }
+  if (process.platform === 'win32') {
+    // Windows 截图默认保存到 图片\屏幕截图
+    return path.join(os.homedir(), 'Pictures', 'Screenshots');
+  }
   return path.join(os.homedir(), 'Desktop');
 }
 let shotWatcher = null;
 const shotSent = new Map(); // path -> t，fs.watch 同一文件会连发多个事件，3s 内去重
 function startShotWatch() {
-  if (process.platform !== 'darwin' || shotWatcher) return;
+  if (shotWatcher) return;
   const dir = screenshotDir();
   if (!fs.existsSync(dir)) return;
   try {
     shotWatcher = fs.watch(dir, { persistent: false }, (evt, filename) => {
       const name = filename ? filename.toString() : '';
       // 截屏写盘有「.截屏xxx.png」点前缀的中间态，跳过；只认系统截屏的命名习惯
-      if (!/^(截屏|截圖|截图|Screenshot|Screen Shot|CleanShot|SCR-)/i.test(name) || !/\.(png|jpe?g)$/i.test(name)) return;
+      // macOS: 截屏/Screenshot/Screen Shot/CleanShot/SCR-
+      // Windows: Screenshot (Win+Shift+S) / 屏幕截图
+      if (!/^(截屏|截圖|截图|Screenshot|Screen Shot|CleanShot|SCR-|屏幕截图)/i.test(name) || !/\.(png|jpe?g|bmp)$/i.test(name)) return;
       const fp = path.join(dir, name);
       setTimeout(() => { // 等写盘完成再确认
         fs.stat(fp, (err, st) => {
@@ -296,9 +315,15 @@ ipcMain.handle('clip:image', (e, { path: p }) => {
   catch (err) { return { ok: false, error: err.message }; }
 });
 ipcMain.handle('clip:file', (e, { path: p }) => new Promise((resolve) => {
-  const { execFile } = require('child_process');
-  // argv 传路径，避免拼进 AppleScript 字面量被注入
-  execFile('osascript', ['-e', 'on run argv', '-e', 'set the clipboard to (POSIX file (item 1 of argv))', '-e', 'end run', p], (err) => resolve({ ok: !err, error: err && err.message }));
+  const { execFile, exec } = require('child_process');
+  if (process.platform === 'win32') {
+    // Windows: 用 PowerShell 复制文件到剪贴板
+    const ps = p.replace(/'/g, "''");
+    exec(`powershell -NoProfile -Command "Set-Clipboard -Path '${ps}'"`, (err) => resolve({ ok: !err, error: err && err.message }));
+  } else {
+    // macOS: argv 传路径，避免拼进 AppleScript 字面量被注入
+    execFile('osascript', ['-e', 'on run argv', '-e', 'set the clipboard to (POSIX file (item 1 of argv))', '-e', 'end run', p], (err) => resolve({ ok: !err, error: err && err.message }));
+  }
 }));
 
 // 拖拽落盘：file-promise 类拖入（截图浮窗等）没有真实路径，把字节写进临时目录换路径
@@ -366,11 +391,20 @@ ipcMain.handle('pty:cwd', (e, { id }) => new Promise((resolve) => {
   const p = terminals.get(id);
   if (!p || !p.pid) return resolve({ ok: false });
   const { exec } = require('child_process');
-  exec(`lsof -a -p ${p.pid} -d cwd -Fn`, { env: { ...process.env, LC_ALL: 'en_US.UTF-8' } }, (err, stdout) => {
-    if (err) return resolve({ ok: false });
-    const line = stdout.split('\n').find((l) => l.startsWith('n'));
-    resolve(line ? { ok: true, cwd: decodeLsofPath(line.slice(1)) } : { ok: false });
-  });
+  if (process.platform === 'win32') {
+    // Windows: 用 wmic 获取进程工作目录
+    exec(`wmic process where ProcessId=${p.pid} get CommandLine /format:list`, { encoding: 'utf8' }, (err, stdout) => {
+      if (err) return resolve({ ok: false });
+      // 无法直接获取 cwd，返回 home 作为兜底
+      resolve({ ok: false });
+    });
+  } else {
+    exec(`lsof -a -p ${p.pid} -d cwd -Fn`, { env: { ...process.env, LC_ALL: 'en_US.UTF-8' } }, (err, stdout) => {
+      if (err) return resolve({ ok: false });
+      const line = stdout.split('\n').find((l) => l.startsWith('n'));
+      resolve(line ? { ok: true, cwd: decodeLsofPath(line.slice(1)) } : { ok: false });
+    });
+  }
 }));
 
 // 取终端前台进程名（node-pty 维护）：判断当前是裸 shell 还是正跑着 claude/codex 等程序

--- a/package.json
+++ b/package.json
@@ -43,6 +43,27 @@
         }
       ]
     },
+    "win": {
+      "icon": "build/icon.ico",
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true,
+      "installerIcon": "build/icon.ico",
+      "uninstallerIcon": "build/icon.ico",
+      "installerHeaderIcon": "build/icon.ico",
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true,
+      "shortcutName": "FanBox"
+    },
     "dmg": {
       "title": "FanBox",
       "writeUpdateInfo": false
@@ -60,7 +81,7 @@
     "node-pty": "^1.0.0"
   },
   "devDependencies": {
-    "@electron/rebuild": "^3.7.0",
+    "@electron/rebuild": "^3.7.2",
     "@milkdown/crepe": "^7.21.2",
     "electron": "^33.2.0",
     "electron-builder": "^25.1.8",

--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,11 @@
 const $ = (s) => document.querySelector(s);
 const api = (p) => fetch(p).then((r) => r.json());
 const apiPost = (p, body) => fetch(p, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).then((r) => r.json());
+// 平台感知的快捷键符号：macOS 用 ⌘，Windows/Linux 用 Ctrl
+function modKey() {
+  const p = (window.fanboxEnv && window.fanboxEnv.platform) || navigator.platform || '';
+  return /mac|darwin/i.test(p) ? '⌘' : 'Ctrl';
+}
 
 // ---------- SVG 图标系统（替代 emoji，统一矢量审美） ----------
 const SVG = {
@@ -1014,7 +1019,7 @@ function buildImageEditor(e, img) {
       </div>
       <input type="color" id="ie-color" value="#ff3b30" title="颜色">
       <span class="ie-thick" title="粗细"><input type="range" id="ie-size" min="1" max="60" value="5"><i id="ie-dot"></i></span>
-      <button id="ie-undo" class="ghost-btn" title="撤销 ⌘Z">撤销</button>
+      <button id="ie-undo" class="ghost-btn" title="撤销 ${modKey()}Z">撤销</button>
     </div>
     <div class="imgedit-canvas-wrap"><canvas id="ie-canvas"></canvas></div>
     <div class="imgedit-export">
@@ -1205,7 +1210,7 @@ async function enterEditMode(e) {
   let getValue, baseline = ''; // baseline：编辑器内的「已保存基准」，用于未保存守卫
   const leave = async () => {
     if (getValue && getValue() !== baseline) {
-      const ok = await confirmDialog('有未保存的改动，放弃并退出？（保存请点取消后按 ⌘S）');
+      const ok = await confirmDialog(`有未保存的改动，放弃并退出？（保存请点取消后按 ${modKey()}S）`);
       if (!ok) return;
     }
     dirtyCheck = null; // 已在此确认过，避免 openPreview 的守卫再问一次
@@ -1230,7 +1235,7 @@ async function enterEditMode(e) {
   if (await mona.load()) {
     const monaco = window.monaco;
     body.innerHTML =
-      `<div class="editor-bar"><button id="ed-save" class="primary">保存</button><button id="ed-cancel" class="ghost-btn">完成</button><span class="editor-hint">⌘S 保存 · ⌘F 查找 · Esc 完成</span></div>` +
+      `<div class="editor-bar"><button id="ed-save" class="primary">保存</button><button id="ed-cancel" class="ghost-btn">完成</button><span class="editor-hint">${modKey()}S 保存 · ${modKey()}F 查找 · Esc 完成</span></div>` +
       `<div id="ed-host" class="mona-host"></div>`;
     const ed = monaco.editor.create($('#ed-host'), {
       value: data.content || '', language: mona.lang(ex), theme: mona.themeName(),
@@ -1247,7 +1252,7 @@ async function enterEditMode(e) {
     setTimeout(() => ed.focus(), 0);
   } else {
     body.innerHTML =
-      `<div class="editor-bar"><button id="ed-save" class="primary">保存</button><button id="ed-cancel" class="ghost-btn">完成</button><span class="editor-hint">⌘S 保存 · Esc 完成</span></div>` +
+      `<div class="editor-bar"><button id="ed-save" class="primary">保存</button><button id="ed-cancel" class="ghost-btn">完成</button><span class="editor-hint">${modKey()}S 保存 · Esc 完成</span></div>` +
       `<textarea id="ed-host" class="editor-area" spellcheck="false"></textarea>`;
     const ta = $('#ed-host');
     ta.value = data.content || '';
@@ -1299,7 +1304,7 @@ async function mdEditor(e, data, mode = 'rich') {
     mode = m;
     mona.disposeIfAny(); crepe.disposeIfAny();
     body.innerHTML =
-      `<div class="editor-bar"><button id="md-mode" class="ghost-btn">${m === 'rich' ? '源码' : '富文本'}</button><span id="md-status" class="editor-hint">自动保存 · ⌘S 立即保存</span></div>` +
+      `<div class="editor-bar"><button id="md-mode" class="ghost-btn">${m === 'rich' ? '源码' : '富文本'}</button><span id="md-status" class="editor-hint">自动保存 · ${modKey()}S 立即保存</span></div>` +
       `<div id="ed-host" class="${m === 'rich' ? 'crepe-host' : 'mona-host'}"></div>`;
     $('#md-mode').onclick = async () => {
       await flush();
@@ -1888,7 +1893,7 @@ function maybeShowGuide() {
     <h2>欢迎用 FanBox</h2>
     <p>vibe coding 的驾驶舱——找文件、跑 agent、看它改、随手改，都在一个窗口：</p>
     <ul>
-      <li><b>⌘K</b> 全局搜文件和文件夹；<b>⌘↵</b> 把项目直接在编辑器整包打开；<code>内容:关键词</code> 搜文件里的字</li>
+      <li><b>${modKey()}K</b> 全局搜文件和文件夹；<b>${modKey()}↵</b> 把项目直接在编辑器整包打开；<code>内容:关键词</code> 搜文件里的字</li>
       <li>顶部 <b>终端</b> 按钮开内嵌终端跑 Claude Code 等 agent；<b>把文件/文件夹拖进终端</b> 即插入路径喂给它当上下文</li>
       <li><b>单击</b> 预览，<b>双击</b> 系统打开；预览里 <b>编辑</b> md 走所见即所得、<b>编辑图片</b> 可标注/打码/转格式</li>
       <li>agent 改了哪些文件，列表实时高亮「改·N」，不用切窗口盯着看</li>
@@ -3722,7 +3727,11 @@ if (window.fanboxFs) {
 // ---------- 启动 ----------
 async function init() {
   // 桌面 app：标记 body，给顶部交通灯留位、顶部可拖拽
-  if (window.fanboxEnv && window.fanboxEnv.isDesktopApp) document.documentElement.classList.add('desktop');
+  if (window.fanboxEnv && window.fanboxEnv.isDesktopApp) {
+    document.documentElement.classList.add('desktop');
+    if (window.fanboxEnv.platform === 'win32') document.documentElement.classList.add('win');
+    if (window.fanboxEnv.platform === 'darwin') document.documentElement.classList.add('mac');
+  }
   applyTheme(state.theme, false);
   if (state.sidebarCollapsed) { $('#app').classList.add('sidebar-collapsed'); $('#btn-sidebar')?.classList.add('on'); }
   applyLayout();

--- a/public/style.css
+++ b/public/style.css
@@ -870,14 +870,23 @@ kbd {
 
 /* ---------- 桌面 app：交通灯避让 + 顶部可拖拽 ---------- */
 /* hiddenInset 标题栏的红绿灯坐在左上角，给侧栏 logo 让出空间（浏览器版无此问题，不受影响）*/
-.desktop #sidebar { padding-top: 40px; }
+/* 仅 macOS 需要避让，Windows 不需要 */
+.mac.desktop #sidebar { padding-top: 40px; }
+/* Windows：给 titleBarOverlay 留出顶部空间 + 右侧避让（最小化/最大化/关闭按钮约 130px） */
+.win.desktop #sidebar { padding-top: 48px; }
+.win.desktop #topbar { padding: 12px 160px 12px 12px; min-height: 48px; }
+/* macOS 顶栏也给点呼吸感 */
+.mac.desktop #topbar { padding-top: 8px; padding-bottom: 8px; }
 .desktop .brand { -webkit-app-region: drag; }
-/* 顶栏空白处也可拖窗，但其中的按钮/面包屑保持可点 */
+/* 整个顶栏可拖拽 */
 .desktop #topbar { -webkit-app-region: drag; }
 /* 侧栏不做整体拖拽区：#sidebar 自身是滚动容器（overflow-y:auto），而 Electron 的
    app-region:drag 区域收不到滚轮事件——整栏 drag 会让滚动时灵时卡（#6 的方案回退）。
    拖窗用品牌区和顶栏，足够顺手 */
-.desktop #topbar button, .desktop #topbar .breadcrumb, .desktop #topbar .seg, .desktop #topbar .toggle, .desktop #topbar input { -webkit-app-region: no-drag; }
+.desktop #topbar > * { -webkit-app-region: no-drag; }
+/* 面包屑和空白处恢复拖拽 */
+.desktop #topbar .breadcrumb { -webkit-app-region: drag; }
+.desktop #topbar .breadcrumb * { -webkit-app-region: no-drag; }
 
 /* 终端头：跟随/定位 文字按钮 */
 .term-actions #file-follow, .term-actions #term-locate { font-size: 11px; padding: 3px 8px; font-family: var(--font-ui); }
@@ -895,7 +904,10 @@ kbd {
 /* 浏览器版的纸纹来自 body、能从无背景的主区透出；桌面 app 上面这组不透明底色会盖住它，单独补回 */
 .desktop[data-theme="warm"] #main, .desktop[data-theme="warm"] #content { background-image: radial-gradient(rgba(140, 110, 70, 0.05) 1px, transparent 1px); background-size: 4px 4px; }
 .desktop #topbar { background-color: var(--bg-2); }
-.desktop #sidebar { background-color: color-mix(in srgb, var(--panel) 80%, transparent); }
+/* macOS：毛玻璃半透明 */
+.mac.desktop #sidebar { background-color: color-mix(in srgb, var(--panel) 80%, transparent); }
+/* Windows：不透明背景（不支持 vibrancy） */
+.win.desktop #sidebar { background-color: var(--panel); }
 
 /* 跟随/定位 改为图标+文字，覆盖前面的纯文字规则 */
 .term-actions #file-follow, .term-actions #term-locate { display: inline-flex; align-items: center; gap: 4px; }


### PR DESCRIPTION
## 🪟 Windows 桌面版支持

### 改动内容
- **electron/main.js**: Windows 标题栏适配 (titleBarOverlay)、截图目录检测、剪贴板文件复制、终端 cwd 获取
- **public/app.js**: 添加  函数，快捷键符号自动适配 (macOS→⌘, Windows→Ctrl)、平台 CSS 类
- **public/style.css**: 交通灯 padding 仅 macOS 生效、Windows 用不透明侧栏背景、拖拽区域优化
- **package.json**: 添加 Windows NSIS 安装包构建配置
- **build/icon.ico**: 新增 Windows 图标文件 (16-256px)

### 技术细节
- **标题栏**: 使用  +  实现自定义标题栏
- **截图监听**: Windows 监听  目录
- **剪贴板**: 使用 PowerShell 的  实现文件复制
- **快捷键**: 根据平台动态显示  或 

### 测试环境
- Windows 11 Pro
- Node.js v24.14.1
- Electron 33.4.11

### 说明
我是文科生，不会写代码，用 Claude Code 完成了这次适配。希望能让更多 Windows 用户用上 FanBox！

已发布 Windows 版：https://github.com/daodao166888/fanbox-windows