### PR TITLE
fix: 终端 ⌘V 粘贴图片失效（#27 回归）

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3273,10 +3273,14 @@ const term = {
         // ⌘V 粘贴：空文本也要 paste('') 发出 bracketed-paste 序列。
         // 图片粘贴靠的是 claude 收到粘贴信号后主动读系统剪贴板取图；若这里因「无文本」
         // 就不调 xterm.paste，终端收不到任何信号，claude 永远不会去读图 → 图片粘贴失效（#图片粘贴回归）
+        sess._kbPasteTs = Date.now(); // 标记这次粘贴由键盘接管，供下方拦掉 xterm 原生 paste 事件，防双发（Ctrl+V 图片粘两张）
+        sess._pasteFallback = '';     // 清掉上次的兜底文本，避免陈旧误用
         e.preventDefault();
         navigator.clipboard.readText()
           .then(text => xterm.paste(text || ''))
-          .catch(() => xterm.paste('')); // 纯图片剪贴板 readText 会返回空/reject，同样补发空粘贴信号
+          // readText 无权限/非安全上下文会 reject：用原生 paste 事件抓到的 clipboardData 文本兜底，
+          // 别让这些环境下文本粘贴失效（图片剪贴板没有文本，兜底为空，仍是空信号让 claude 去读图）
+          .catch(() => xterm.paste(sess._pasteFallback || ''));
         return false;
       }
       if (cmd && (e.key === '=' || e.key === '+' || e.key === '0')) {
@@ -3292,6 +3296,22 @@ const term = {
       }
       return true;
     });
+
+    // 防双重粘贴：⌘V/Ctrl+V 已由上面的键盘处理器接管（navigator.clipboard + xterm.paste），
+    // 但 xterm 自带的原生 paste 监听会对同一次按键再发一遍 bracketed-paste，claude 便读两次剪贴板
+    //  → 图片粘两张（Cmd+V 时 preventDefault 顺带压掉了原生事件，Ctrl+V 压不住，故只有 Ctrl+V 双发）。
+    // 只吞「键盘刚接管」紧随的那一次原生 paste：一次性消费（命中即置 0），60ms 仅作兜底上限——
+    // 原生 paste 是按键默认动作、几毫秒内必到，60ms 足够拦住；而人手二次粘贴间隔 >150ms，
+    // 故即便某次没等到原生 paste（如 Cmd+V 原生事件已被 preventDefault 取消）致标记未被消费，
+    // 60ms 内也活不到下一次真实粘贴 → 不会误吞紧接着的合法粘贴。
+    // 拦掉前先把它携带的 clipboardData 文本存下：上面 readText 失败时用它兜底，保住文本粘贴不失效。
+    host.addEventListener('paste', (e) => {
+      if (Date.now() - (sess._kbPasteTs || 0) < 60) {
+        sess._kbPasteTs = 0; // 一次性：消费掉，后续粘贴（含快速再点「编辑→粘贴」）不再受这次按键影响
+        try { sess._pasteFallback = (e.clipboardData && e.clipboardData.getData('text/plain')) || ''; } catch { /* */ }
+        e.preventDefault(); e.stopImmediatePropagation();
+      }
+    }, true);
 
     // 右键菜单：复制/粘贴
     host.addEventListener('contextmenu', (e) => {

--- a/public/app.js
+++ b/public/app.js
@@ -3270,11 +3270,13 @@ const term = {
         return true;
       }
       if (cmd && (e.key === 'v' || e.key === 'V')) {
-        // ⌘V 粘贴
+        // ⌘V 粘贴：空文本也要 paste('') 发出 bracketed-paste 序列。
+        // 图片粘贴靠的是 claude 收到粘贴信号后主动读系统剪贴板取图；若这里因「无文本」
+        // 就不调 xterm.paste，终端收不到任何信号，claude 永远不会去读图 → 图片粘贴失效（#图片粘贴回归）
         e.preventDefault();
-        navigator.clipboard.readText().then(text => {
-          if (text) xterm.paste(text);
-        }).catch(() => { /* 无权限时走Electron菜单兜底 */ });
+        navigator.clipboard.readText()
+          .then(text => xterm.paste(text || ''))
+          .catch(() => xterm.paste('')); // 纯图片剪贴板 readText 会返回空/reject，同样补发空粘贴信号
         return false;
       }
       if (cmd && (e.key === '=' || e.key === '+' || e.key === '0')) {


### PR DESCRIPTION
## 问题
自 #27（终端复制粘贴修复）起，在终端里对 claude 等 TUI 按 ⌘V 粘贴**图片**失效；粘贴文本正常。

## 根因
#27 给 ⌘V 加了自定义键盘处理器（`public/app.js`），只在 `readText()` 拿到非空文本时才调 `xterm.paste`：

```js
navigator.clipboard.readText().then(text => { if (text) xterm.paste(text); });
```

图片粘贴的机制是：终端把 bracketed-paste 信号（`\x1b[200~…\x1b[201~`）发给 PTY，claude 收到后**主动读系统剪贴板**取图。纯图片剪贴板的 `readText()` 返回空串/reject，`if (text)` 为假 → `xterm.paste` 从不触发 → claude 收不到信号 → 不读剪贴板 → 图片粘贴失效。

## 修复
无论文本是否为空都转发 `xterm.paste(text || '')`，reject 分支补发 `xterm.paste('')`，还原 #27 之前 xterm 默认粘贴路径。

## 影响面
文本粘贴、⌘C 复制、字号缩放、右键菜单均不受影响。空 bracketed paste 对 shell/claude 是无害 no-op，仅作触发信号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)