### PR TITLE
fix: make Claude usage limits resilient

### DIFF
--- a/lib/claude-official-limits.js
+++ b/lib/claude-official-limits.js
@@ -37,9 +37,14 @@ function execFileP(execFile, cmd, args, options, stdin) {
   });
 }
 
-function pickClaudeAccessToken(raw, now) {
+function parseClaudeOauth(raw) {
   let o;
   try { o = JSON.parse(raw).claudeAiOauth; } catch { return null; }
+  return o || null;
+}
+
+function pickClaudeAccessToken(raw, now) {
+  const o = parseClaudeOauth(raw);
   if (!o || !o.accessToken) return null;
   if (o.expiresAt && o.expiresAt <= now) return null;
   return o.accessToken;
@@ -97,17 +102,23 @@ function createClaudeOfficialLimitsClient(opts) {
     await fsp.writeFile(cacheFile, JSON.stringify({ at: now(), limits }, null, 2));
   }
 
-  async function readToken() {
-    const pick = (raw) => pickClaudeAccessToken(raw, now());
+  async function readCredential() {
     if (platform === 'darwin') {
       try {
         const out = await execFileP(execFile, 'security', ['find-generic-password', '-s', 'Claude Code-credentials', '-w'], { timeout: 3000 });
-        const t = pick(out);
-        if (t) return t;
+        const c = parseClaudeOauth(out);
+        if (c) return c;
       } catch { /* fall back to credentials file */ }
     }
-    try { return pick(await fsp.readFile(path.join(home, '.claude', '.credentials.json'), 'utf8')); }
+    try { return parseClaudeOauth(await fsp.readFile(path.join(home, '.claude', '.credentials.json'), 'utf8')); }
     catch { return null; }
+  }
+
+  async function readToken() {
+    const c = await readCredential();
+    if (!c || !c.accessToken) return null;
+    if (c.expiresAt && c.expiresAt <= now()) return null;
+    return c.accessToken;
   }
 
   async function curlSysProxyLine() {
@@ -125,12 +136,25 @@ function createClaudeOfficialLimitsClient(opts) {
 
   async function refreshClaudeAuthStatus() {
     const childEnv = stripClaudeProviderEnv(env);
-    await execFileP(execFile, claudeBin, ['auth', 'status'], { timeout: 20000, env: childEnv });
+    await execFileP(execFile, claudeBin, [
+      '-p',
+      '--no-session-persistence',
+      '--safe-mode',
+      '--tools',
+      '',
+      '--model',
+      opts.refreshModel || 'haiku',
+      '--output-format',
+      'json',
+      opts.refreshPrompt || 'Reply exactly: OK',
+    ], { timeout: opts.refreshTimeout || 60000, env: childEnv });
   }
 
   async function fetchLive() {
-    const token = await readToken();
-    if (!token) throw new Error('claude_oauth_token_missing');
+    const credential = await readCredential();
+    if (!credential || !credential.accessToken) throw new Error('claude_oauth_token_missing');
+    if (credential.expiresAt && credential.expiresAt <= now()) throw new Error('claude_oauth_token_expired');
+    const token = credential.accessToken;
     const proxyLine = await curlSysProxyLine();
     const body = await execFileP(
       execFile,

--- a/lib/claude-official-limits.js
+++ b/lib/claude-official-limits.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const path = require('path');
+
+const CLAUDE_PROVIDER_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+];
+
+function stripClaudeProviderEnv(env) {
+  const out = { ...(env || {}) };
+  for (const key of CLAUDE_PROVIDER_ENV_KEYS) delete out[key];
+  return out;
+}
+
+function safeError(err) {
+  const msg = String((err && err.message) || err || 'unknown');
+  return msg.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, 'Bearer [redacted]').slice(0, 240);
+}
+
+function execFileP(execFile, cmd, args, options, stdin) {
+  return new Promise((resolve, reject) => {
+    const cp = execFile(cmd, args, options, (err, stdout, stderr) => {
+      if (err) {
+        const msg = stderr ? `${err.message}: ${String(stderr).slice(0, 240)}` : err.message;
+        reject(new Error(msg));
+        return;
+      }
+      resolve(String(stdout || ''));
+    });
+    if (stdin != null && cp && cp.stdin) cp.stdin.end(stdin);
+  });
+}
+
+function pickClaudeAccessToken(raw, now) {
+  let o;
+  try { o = JSON.parse(raw).claudeAiOauth; } catch { return null; }
+  if (!o || !o.accessToken) return null;
+  if (o.expiresAt && o.expiresAt <= now) return null;
+  return o.accessToken;
+}
+
+function parseUsageBody(body) {
+  let payload = String(body || '');
+  let status = 0;
+  const idx = payload.lastIndexOf('\n');
+  const tail = idx >= 0 ? payload.slice(idx + 1).trim() : '';
+  if (/^\d{3}$/.test(tail)) {
+    status = Number(tail);
+    payload = payload.slice(0, idx);
+  }
+  if (status >= 400) throw new Error(`usage_http_${status}`);
+  const d = JSON.parse(payload);
+  const win = (w) => (w && w.utilization != null)
+    ? { usedPercent: w.utilization, resetsAt: w.resets_at ? Math.floor(Date.parse(w.resets_at) / 1000) : 0 }
+    : null;
+  const fiveHour = win(d.five_hour), sevenDay = win(d.seven_day);
+  return (fiveHour || sevenDay) ? { fiveHour, sevenDay } : null;
+}
+
+function normalizeCachedLimits(limits, nowMs) {
+  if (!limits) return null;
+  const normalize = (w) => {
+    if (!w) return null;
+    if (w.resetsAt && w.resetsAt * 1000 < nowMs) return { ...w, usedPercent: 0, resetsAt: 0 };
+    return w;
+  };
+  return { fiveHour: normalize(limits.fiveHour), sevenDay: normalize(limits.sevenDay) };
+}
+
+function createClaudeOfficialLimitsClient(opts) {
+  const home = opts.home;
+  const platform = opts.platform || process.platform;
+  const execFile = opts.execFile;
+  const fsp = opts.fsp;
+  const env = opts.env || process.env;
+  const now = opts.now || Date.now;
+  const cacheFile = opts.cacheFile || path.join(opts.configDir || path.join(home, '.fanbox'), 'claude-official-limits-cache.json');
+  const claudeBin = opts.claudeBin || path.join(home, '.local', 'bin', 'claude');
+  let memoryCache = null;
+
+  async function readCache() {
+    try {
+      const c = JSON.parse(await fsp.readFile(cacheFile, 'utf8'));
+      return c && c.limits ? c : null;
+    } catch { return null; }
+  }
+
+  async function writeCache(limits) {
+    if (!limits) return;
+    await fsp.mkdir(path.dirname(cacheFile), { recursive: true }).catch(() => {});
+    await fsp.writeFile(cacheFile, JSON.stringify({ at: now(), limits }, null, 2));
+  }
+
+  async function readToken() {
+    const pick = (raw) => pickClaudeAccessToken(raw, now());
+    if (platform === 'darwin') {
+      try {
+        const out = await execFileP(execFile, 'security', ['find-generic-password', '-s', 'Claude Code-credentials', '-w'], { timeout: 3000 });
+        const t = pick(out);
+        if (t) return t;
+      } catch { /* fall back to credentials file */ }
+    }
+    try { return pick(await fsp.readFile(path.join(home, '.claude', '.credentials.json'), 'utf8')); }
+    catch { return null; }
+  }
+
+  async function curlSysProxyLine() {
+    if (['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY', 'all_proxy', 'ALL_PROXY'].some((k) => env[k])) return '';
+    if (platform !== 'darwin') return '';
+    try {
+      const out = await execFileP(execFile, 'scutil', ['--proxy'], { timeout: 3000 });
+      const grab = (k) => (out.match(new RegExp(`\\b${k} : (\\S+)`)) || [])[1];
+      if (grab('HTTPSEnable') === '1') return `proxy = "http://${grab('HTTPSProxy')}:${grab('HTTPSPort')}"\n`;
+      if (grab('HTTPEnable') === '1') return `proxy = "http://${grab('HTTPProxy')}:${grab('HTTPPort')}"\n`;
+      if (grab('SOCKSEnable') === '1') return `proxy = "socks5h://${grab('SOCKSProxy')}:${grab('SOCKSPort')}"\n`;
+    } catch { /* direct connection fallback */ }
+    return '';
+  }
+
+  async function refreshClaudeAuthStatus() {
+    const childEnv = stripClaudeProviderEnv(env);
+    await execFileP(execFile, claudeBin, ['auth', 'status'], { timeout: 20000, env: childEnv });
+  }
+
+  async function fetchLive() {
+    const token = await readToken();
+    if (!token) throw new Error('claude_oauth_token_missing');
+    const proxyLine = await curlSysProxyLine();
+    const body = await execFileP(
+      execFile,
+      'curl',
+      ['-sS', '--max-time', '8', '-K', '-', '-w', '\n%{http_code}', 'https://api.anthropic.com/api/oauth/usage'],
+      { timeout: 10000 },
+      `${proxyLine}header = "Authorization: Bearer ${token}"\nheader = "anthropic-beta: oauth-2025-04-20"\n`,
+    );
+    const limits = parseUsageBody(body);
+    if (!limits) throw new Error('claude_usage_payload_empty');
+    await writeCache(limits);
+    return { limits, meta: { source: 'live', stale: false, at: now() } };
+  }
+
+  async function fetch(options) {
+    const force = !!(options && options.force);
+    if (!force && memoryCache && now() - memoryCache.meta.at < 30000) return memoryCache;
+    let lastErr = null;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const result = await fetchLive();
+        memoryCache = result;
+        return result;
+      } catch (err) {
+        lastErr = err;
+        if (attempt === 0) {
+          try { await refreshClaudeAuthStatus(); }
+          catch (refreshErr) { lastErr = refreshErr; }
+          continue;
+        }
+      }
+    }
+    const cached = await readCache();
+    if (cached && cached.limits) {
+      const limits = normalizeCachedLimits(cached.limits, now());
+      memoryCache = {
+        limits,
+        meta: { source: 'cache', stale: true, at: cached.at || 0, error: safeError(lastErr) },
+      };
+      return memoryCache;
+    }
+    memoryCache = { limits: null, meta: { source: 'none', stale: true, at: now(), error: safeError(lastErr) } };
+    return memoryCache;
+  }
+
+  return { fetch, refreshClaudeAuthStatus, readToken };
+}
+
+module.exports = {
+  CLAUDE_PROVIDER_ENV_KEYS,
+  createClaudeOfficialLimitsClient,
+  normalizeCachedLimits,
+  parseUsageBody,
+  pickClaudeAccessToken,
+  stripClaudeProviderEnv,
+};

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const os = require('os');
 const crypto = require('crypto');
 const { exec, spawn, execFile } = require('child_process');
 const { URL } = require('url');
+const { createClaudeOfficialLimitsClient } = require('./lib/claude-official-limits');
 
 const HOME = os.homedir();
 const PORT = Number(process.env.FANBOX_PORT) || 4567;
@@ -23,6 +24,14 @@ const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 const THUMB_DIR = path.join(CONFIG_DIR, 'thumbs');
 const PUBLIC = path.join(__dirname, 'public');
 const PLATFORM = process.platform;
+const claudeOfficialClient = createClaudeOfficialLimitsClient({
+  home: HOME,
+  configDir: CONFIG_DIR,
+  platform: PLATFORM,
+  execFile,
+  fsp,
+  env: process.env,
+});
 
 // 搜索 / 遍历时跳过的重目录，避免 vibe coding 项目里 node_modules 拖垮速度
 const IGNORE_DIRS = new Set([
@@ -1652,64 +1661,10 @@ async function codexUsage() {
   return null;
 }
 
-// Claude Code 官方限额窗口（和它 /usage 面板同源）：5h 滚动窗口 + 周配额的百分比和重置时间。
-// 本地 jsonl 只有 token 流水、推不出官方百分比，必须拿 Claude Code 自己的 OAuth token
-// （macOS 在 Keychain，其他平台落在 ~/.claude/.credentials.json）查官方 usage 接口。
-// 这是本服务唯一的出网请求，只发往 api.anthropic.com——Claude Code 平时也在发同一个请求。
-async function claudeOAuthToken() {
-  const pick = (raw) => {
-    const o = JSON.parse(raw).claudeAiOauth;
-    return o && o.accessToken && (!o.expiresAt || o.expiresAt > Date.now()) ? o.accessToken : null;
-  };
-  if (PLATFORM === 'darwin') {
-    try {
-      const out = await new Promise((resolve, reject) => {
-        execFile('security', ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
-          { timeout: 3000 }, (err, stdout) => (err ? reject(err) : resolve(stdout)));
-      });
-      const t = pick(out);
-      if (t) return t;
-    } catch { /* 落到凭证文件 */ }
-  }
-  try { return pick(await fsp.readFile(path.join(HOME, '.claude', '.credentials.json'), 'utf8')); }
-  catch { return null; }
-}
-
-// 终端启动时 curl 自己会认 http_proxy 等环境变量；但打包 App 从 Finder/Dock 启动没有这些变量，
-// curl 直连 api.anthropic.com 会被 403 地域拦截。此时读 macOS 系统代理（Clash 等都会写进去）兜底。
-async function curlSysProxyLine() {
-  if (['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY', 'all_proxy', 'ALL_PROXY'].some((k) => process.env[k])) return '';
-  if (PLATFORM !== 'darwin') return '';
-  try {
-    const out = await new Promise((resolve, reject) => {
-      execFile('scutil', ['--proxy'], { timeout: 3000 }, (err, stdout) => (err ? reject(err) : resolve(stdout)));
-    });
-    const grab = (k) => (out.match(new RegExp(`\\b${k} : (\\S+)`)) || [])[1];
-    if (grab('HTTPSEnable') === '1') return `proxy = "http://${grab('HTTPSProxy')}:${grab('HTTPSPort')}"\n`;
-    if (grab('HTTPEnable') === '1') return `proxy = "http://${grab('HTTPProxy')}:${grab('HTTPPort')}"\n`;
-    if (grab('SOCKSEnable') === '1') return `proxy = "socks5h://${grab('SOCKSProxy')}:${grab('SOCKSPort')}"\n`;
-  } catch { /* 读不到就直连 */ }
-  return '';
-}
-
-async function claudeOfficialLimits() {
-  const token = await claudeOAuthToken();
-  if (!token) return null;
-  // 不用 Node https：该接口的防护按 TLS 指纹拦——同样的请求头 curl 能 200、Node 直接 403。
-  // 走系统 curl（macOS/Win10+ 自带），顺带继承用户的代理环境变量；
-  // token 经 stdin 的 curl 配置传入，不暴露在进程列表里
-  const proxyLine = await curlSysProxyLine();
-  const body = await new Promise((resolve, reject) => {
-    const cp = execFile('curl', ['-sS', '--max-time', '8', '-K', '-', 'https://api.anthropic.com/api/oauth/usage'],
-      { timeout: 10000 }, (err, stdout) => (err ? reject(err) : resolve(stdout)));
-    cp.stdin.end(`${proxyLine}header = "Authorization: Bearer ${token}"\nheader = "anthropic-beta: oauth-2025-04-20"\n`);
-  });
-  const d = JSON.parse(body);
-  const win = (w) => (w && w.utilization != null)
-    ? { usedPercent: w.utilization, resetsAt: w.resets_at ? Math.floor(Date.parse(w.resets_at) / 1000) : 0 }
-    : null;
-  const fiveHour = win(d.five_hour), sevenDay = win(d.seven_day);
-  return (fiveHour || sevenDay) ? { fiveHour, sevenDay } : null;
+// Claude Code 官方限额窗口（和它 /usage 面板同源）：5h 滚动窗口 + 周配额。
+// 失败时先用真实 Claude CLI 刷新官方 OAuth 状态，仍失败则返回上次成功缓存，避免 UI 掉到 official:null。
+async function claudeOfficialLimits(force = false) {
+  return await claudeOfficialClient.fetch({ force });
 }
 
 // ---------- Agent 项目（最近被 coding agent 处理过的项目文件夹）----------
@@ -2090,14 +2045,16 @@ async function skillTrash(dir) {
   return r;
 }
 
-async function agentUsage() {
-  if (usageResultCache.data && Date.now() - usageResultCache.at < 30000) return usageResultCache.data;
+async function agentUsage(force = false) {
+  if (!force && usageResultCache.data && Date.now() - usageResultCache.at < 30000) return usageResultCache.data;
   const [claude, codex, claudeLimits] = await Promise.all([
     claudeUsage().catch(() => null),
     codexUsage().catch(() => null),
-    claudeOfficialLimits().catch(() => null),
+    claudeOfficialLimits(force).catch(() => null),
   ]);
-  const claudeOut = (claude || claudeLimits) ? { ...(claude || {}), official: claudeLimits } : null;
+  const official = claudeLimits && claudeLimits.limits ? claudeLimits.limits : null;
+  const officialMeta = claudeLimits && claudeLimits.meta ? claudeLimits.meta : null;
+  const claudeOut = (claude || official) ? { ...(claude || {}), official, officialMeta } : null;
   const data = { ok: true, at: Date.now(), claude: claudeOut, codex };
   usageResultCache = { at: Date.now(), data };
   return data;
@@ -2319,7 +2276,8 @@ const server = http.createServer(async (req, res) => {
       return sendJSON(res, 200, await skillTrash(b.dir));
     }
     if (p === '/api/agent-usage') {
-      return sendJSON(res, 200, await agentUsage());
+      const force = url.searchParams.get('force') === '1' || url.searchParams.get('refresh') === '1';
+      return sendJSON(res, 200, await agentUsage(force));
     }
     if (p === '/api/favorites') {
       if (req.method === 'POST') {

--- a/test/claude-official-limits.test.js
+++ b/test/claude-official-limits.test.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  CLAUDE_PROVIDER_ENV_KEYS,
+  createClaudeOfficialLimitsClient,
+  normalizeCachedLimits,
+  stripClaudeProviderEnv,
+} = require('../lib/claude-official-limits');
+
+test('stripClaudeProviderEnv removes provider routing without mutating the original env', () => {
+  const original = {
+    PATH: '/usr/bin',
+    ANTHROPIC_API_KEY: 'deepseek-key',
+    ANTHROPIC_AUTH_TOKEN: 'deepseek-token',
+    ANTHROPIC_BASE_URL: 'https://deepseek.example',
+    ANTHROPIC_MODEL: 'deepseek-model',
+    ANTHROPIC_SMALL_FAST_MODEL: 'deepseek-small',
+    CLAUDE_CODE_USE_BEDROCK: '1',
+    CLAUDE_CODE_USE_VERTEX: '1',
+    KEEP_ME: 'yes',
+  };
+
+  const stripped = stripClaudeProviderEnv(original);
+
+  for (const key of CLAUDE_PROVIDER_ENV_KEYS) assert.equal(stripped[key], undefined);
+  assert.equal(stripped.PATH, '/usr/bin');
+  assert.equal(stripped.KEEP_ME, 'yes');
+  assert.equal(original.ANTHROPIC_BASE_URL, 'https://deepseek.example');
+});
+
+test('limits returns stale cache when live usage fails after isolated refresh', async () => {
+  const calls = [];
+  const files = new Map([
+    ['/home/user/.fanbox/claude-official-limits-cache.json', JSON.stringify({
+      at: 1783000000000,
+      limits: {
+        fiveHour: { usedPercent: 33, resetsAt: 1783001000 },
+        sevenDay: { usedPercent: 44, resetsAt: 1783600000 },
+      },
+    })],
+  ]);
+  const fakeFsp = {
+    readFile: async (file) => {
+      if (!files.has(file)) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+      return files.get(file);
+    },
+    writeFile: async (file, value) => { files.set(file, value); },
+    mkdir: async () => {},
+  };
+  const fakeExecFile = (cmd, args, options, cb) => {
+    calls.push({ cmd, args, env: options.env });
+    if (cmd.endsWith('/claude')) return cb(null, '{"loggedIn":true,"authMethod":"claude.ai"}');
+    if (cmd === 'security') return cb(new Error('no keychain'), '');
+    if (cmd === 'curl') return cb(new Error('network down'), '');
+    return cb(new Error('unexpected command'), '');
+  };
+
+  const client = createClaudeOfficialLimitsClient({
+    home: '/home/user',
+    platform: 'darwin',
+    execFile: fakeExecFile,
+    fsp: fakeFsp,
+    env: {
+      PATH: '/usr/bin',
+      ANTHROPIC_BASE_URL: 'https://deepseek.example',
+      ANTHROPIC_AUTH_TOKEN: 'token',
+    },
+    now: () => 1783000100000,
+  });
+
+  const result = await client.fetch({ force: true });
+
+  assert.equal(result.limits.fiveHour.usedPercent, 33);
+  assert.equal(result.meta.source, 'cache');
+  assert.equal(result.meta.stale, true);
+  const refresh = calls.find((c) => c.cmd.endsWith('/claude'));
+  assert.ok(refresh);
+  assert.deepEqual(refresh.args, ['auth', 'status']);
+  assert.equal(refresh.env.ANTHROPIC_BASE_URL, undefined);
+  assert.equal(refresh.env.ANTHROPIC_AUTH_TOKEN, undefined);
+});
+
+test('normalizeCachedLimits zeroes windows that already reset', () => {
+  const limits = normalizeCachedLimits({
+    fiveHour: { usedPercent: 80, resetsAt: 100 },
+    sevenDay: { usedPercent: 45, resetsAt: 300 },
+  }, 200000);
+
+  assert.equal(limits.fiveHour.usedPercent, 0);
+  assert.equal(limits.fiveHour.resetsAt, 0);
+  assert.equal(limits.sevenDay.usedPercent, 45);
+  assert.equal(limits.sevenDay.resetsAt, 300);
+});

--- a/test/claude-official-limits.test.js
+++ b/test/claude-official-limits.test.js
@@ -75,7 +75,72 @@ test('limits returns stale cache when live usage fails after isolated refresh', 
   assert.equal(result.meta.stale, true);
   const refresh = calls.find((c) => c.cmd.endsWith('/claude'));
   assert.ok(refresh);
-  assert.deepEqual(refresh.args, ['auth', 'status']);
+  assert.deepEqual(refresh.args.slice(0, 6), ['-p', '--no-session-persistence', '--safe-mode', '--tools', '', '--model']);
+  assert.equal(refresh.env.ANTHROPIC_BASE_URL, undefined);
+  assert.equal(refresh.env.ANTHROPIC_AUTH_TOKEN, undefined);
+});
+
+test('expired oauth token is refreshed with a minimal official Claude request before fetching usage', async () => {
+  const calls = [];
+  let securityReads = 0;
+  const expiredCredential = {
+    claudeAiOauth: {
+      accessToken: 'expired-access',
+      refreshToken: 'refresh-token',
+      expiresAt: 1783000000000,
+    },
+  };
+  const refreshedCredential = {
+    claudeAiOauth: {
+      accessToken: 'fresh-access',
+      refreshToken: 'refresh-token',
+      expiresAt: 1783007200000,
+    },
+  };
+  const fakeFsp = {
+    readFile: async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); },
+    writeFile: async () => {},
+    mkdir: async () => {},
+  };
+  const fakeExecFile = (cmd, args, options, cb) => {
+    calls.push({ cmd, args, env: options.env });
+    if (cmd === 'security') {
+      securityReads++;
+      return cb(null, JSON.stringify(securityReads === 1 ? expiredCredential : refreshedCredential));
+    }
+    if (cmd.endsWith('/claude')) {
+      return cb(null, JSON.stringify({ type: 'result', result: 'OK' }));
+    }
+    if (cmd === 'curl') {
+      assert.match(args.join(' '), /api\/oauth\/usage/);
+      return cb(null, JSON.stringify({
+        five_hour: { utilization: 12, resets_at: '2026-07-09T18:00:00.000Z' },
+        seven_day: { utilization: 34, resets_at: '2026-07-12T18:00:00.000Z' },
+      }) + '\n200');
+    }
+    return cb(new Error(`unexpected command ${cmd}`), '');
+  };
+
+  const client = createClaudeOfficialLimitsClient({
+    home: '/home/user',
+    platform: 'darwin',
+    execFile: fakeExecFile,
+    fsp: fakeFsp,
+    env: {
+      PATH: '/usr/bin',
+      ANTHROPIC_BASE_URL: 'https://deepseek.example',
+      ANTHROPIC_AUTH_TOKEN: 'token',
+    },
+    now: () => 1783000100000,
+  });
+
+  const result = await client.fetch({ force: true });
+
+  assert.equal(result.meta.source, 'live');
+  assert.equal(result.limits.fiveHour.usedPercent, 12);
+  const refresh = calls.find((c) => c.cmd.endsWith('/claude'));
+  assert.ok(refresh);
+  assert.deepEqual(refresh.args.slice(0, 6), ['-p', '--no-session-persistence', '--safe-mode', '--tools', '', '--model']);
   assert.equal(refresh.env.ANTHROPIC_BASE_URL, undefined);
   assert.equal(refresh.env.ANTHROPIC_AUTH_TOKEN, undefined);
 });


### PR DESCRIPTION
## Summary

- extract Claude official usage probing into a testable helper
- retry the official usage request after refreshing Claude auth status with provider routing env vars removed only for that child process
- cache successful official limit responses and return stale metadata instead of dropping to `official: null` when the live probe fails
- add `force=1` / `refresh=1` support for `/api/agent-usage` so watchdogs can bypass the short in-memory cache

## Root cause

FanBox currently returns `claude.official: null` whenever the Keychain credential is expired/missing or the `api.anthropic.com/api/oauth/usage` request fails. The UI then loses the official 5h/week quota display even though local token statistics are still available.

## Notes

The auth refresh uses the real Claude binary path and strips Anthropic/provider routing variables only from that child process. It does not modify user shell wrappers or persistent Claude routing configuration.

## Validation

- `node --check server.js`
- `node --check lib/claude-official-limits.js`
- `node --test test/claude-official-limits.test.js`
