### PR TITLE
fix: sanitize child_process call in server.js...

### DIFF
--- a/server.js
+++ b/server.js
@@ -439,19 +439,21 @@ function trashPath(p) {
     try { target = resolvePath(p); } catch { return resolve({ ok: false, error: '非法路径' }); }
     let isDir = false;
     try { isDir = fs.lstatSync(target).isDirectory(); } catch { return resolve({ ok: false, error: '文件不存在' }); }
-    let cmd;
+    let bin, args;
     if (PLATFORM === 'darwin') {
       // 路径走 argv，不拼进单引号 AppleScript 字面量——避免含 ' 的文件名删除失败/注入
       // POSIX file 必须 as alias 强转，否则 Finder 解析不了报 -1728
-      cmd = `osascript -e 'on run argv' -e 'tell application "Finder" to delete (POSIX file (item 1 of argv) as alias)' -e 'end run' ${shellQuote(target)}`;
+      bin = 'osascript';
+      args = ['-e', 'on run argv', '-e', 'tell application "Finder" to delete (POSIX file (item 1 of argv) as alias)', '-e', 'end run', target];
     } else if (PLATFORM === 'win32') {
       const method = isDir ? 'DeleteDirectory' : 'DeleteFile';
-      const ps = target.replace(/'/g, "''");
-      cmd = `powershell -NoProfile -Command "Add-Type -AssemblyName Microsoft.VisualBasic; [Microsoft.VisualBasic.FileIO.FileSystem]::${method}('${ps}','OnlyErrorDialogs','SendToRecycleBin')"`;
+      bin = 'powershell';
+      args = ['-NoProfile', '-Command', `Add-Type -AssemblyName Microsoft.VisualBasic; [Microsoft.VisualBasic.FileIO.FileSystem]::${method}('${target.replace(/'/g, "''")}','OnlyErrorDialogs','SendToRecycleBin')`];
     } else {
-      cmd = `gio trash ${shellQuote(target)} || trash-put ${shellQuote(target)} || trash ${shellQuote(target)}`;
+      bin = 'sh';
+      args = ['-c', 'gio trash "$1" || trash-put "$1" || trash "$1"', '--', target];
     }
-    exec(cmd, (err) => {
+    execFile(bin, args, (err) => {
       if (!err) return resolve({ ok: true });
       let msg = err.message;
       // Finder 自动化未授权（-1743/-600）给人话
@@ -1239,10 +1241,11 @@ function openInOS(target, withApp) {
     if (withApp === 'terminal') {
       // 在该目录（文件则取其所在目录）打开系统终端，找回项目后一键去跑
       const dir = (() => { try { return fs.statSync(target).isDirectory() ? target : path.dirname(target); } catch { return path.dirname(target); } })();
-      if (PLATFORM === 'darwin') cmd = `open -a Terminal ${shellQuote(dir)}`;
-      else if (PLATFORM === 'win32') cmd = `start "" cmd /K cd /d "${dir}"`;
-      else cmd = `x-terminal-emulator --working-directory=${shellQuote(dir)} || gnome-terminal --working-directory=${shellQuote(dir)} || xterm`;
-      exec(cmd, (err) => resolve(err ? { ok: false, error: err.message } : { ok: true, with: 'terminal' }));
+      let tBin, tArgs;
+      if (PLATFORM === 'darwin') { tBin = 'open'; tArgs = ['-a', 'Terminal', dir]; }
+      else if (PLATFORM === 'win32') { tBin = 'cmd.exe'; tArgs = ['/c', 'start', '', 'cmd', '/K', 'cd', '/d', dir]; }
+      else { tBin = 'sh'; tArgs = ['-c', 'x-terminal-emulator --working-directory="$1" || gnome-terminal --working-directory="$1" || xterm', '--', dir]; }
+      execFile(tBin, tArgs, (err) => resolve(err ? { ok: false, error: err.message } : { ok: true, with: 'terminal' }));
       return;
     }
     if (withApp === 'editor') {
@@ -1263,18 +1266,18 @@ function openInOS(target, withApp) {
 
 function openDefault(target, withApp) {
   return new Promise((resolve) => {
-    let cmd;
+    let bin, args;
     if (PLATFORM === 'darwin') {
-      if (withApp === 'reveal') cmd = `open -R ${shellQuote(target)}`;
-      else cmd = `open ${shellQuote(target)}`;
+      if (withApp === 'reveal') { bin = 'open'; args = ['-R', target]; }
+      else { bin = 'open'; args = [target]; }
     } else if (PLATFORM === 'win32') {
-      if (withApp === 'reveal') cmd = `explorer /select,"${target}"`;
-      else cmd = `start "" "${target}"`;
+      if (withApp === 'reveal') { bin = 'explorer.exe'; args = ['/select,' + target]; }
+      else { bin = 'cmd.exe'; args = ['/c', 'start', '', target]; }
     } else {
-      if (withApp === 'reveal') cmd = `xdg-open ${shellQuote(path.dirname(target))}`;
-      else cmd = `xdg-open ${shellQuote(target)}`;
+      if (withApp === 'reveal') { bin = 'xdg-open'; args = [path.dirname(target)]; }
+      else { bin = 'xdg-open'; args = [target]; }
     }
-    exec(cmd, (err) => {
+    execFile(bin, args, (err) => {
       if (err) resolve({ ok: false, error: err.message });
       else resolve({ ok: true, with: withApp || 'default' });
     });


### PR DESCRIPTION
## Summary
Address high severity security finding in `server.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `server.js:454` |
| **Assessment** | Pattern match — needs manual review |

**Description**: Detected calls to child_process from a function argument `p`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Evidence

**Scanner confirmation**: semgrep rule `javascript.lang.security.detect-child-process.detect-child-process` matched this pattern as javascript.lang.security.detect-child-process.detect-child-process.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `server.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
