### PR TITLE
feat(侧栏): 折叠后鼠标停在窗口左缘自动悬浮侧栏，移开即收

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1109,6 +1109,34 @@ function bindSidebarResizer() {
     localStorage.setItem('fb_sidebar_w', state.sidebarW);
   });
 }
+// 悬浮：折叠态下鼠标停在左缘热区，延时浮出侧栏；离开侧栏延时收起；导航类点击立即收起，开关类不收起
+let peekOpenT, peekCloseT, peekClosedAt = 0;
+function closeSidebarPeek() {
+  clearTimeout(peekOpenT); clearTimeout(peekCloseT); peekCloseT = null; peekClosedAt = Date.now();
+  document.removeEventListener('mousemove', onPeekMove);
+  $('#app').classList.remove('sidebar-peek');
+}
+// 悬浮期间盯全局 mousemove 判断鼠标在不在侧栏里，而不是靠 #sidebar 的 mouseleave：
+// 侧栏是在鼠标静止时浮出来盖住指针的，浏览器不会补发 mouseenter，之后指针一步甩到主区就收不到 mouseleave，悬浮会卡住不收
+function onPeekMove(e) {
+  if ($('#sidebar').contains(e.target)) { clearTimeout(peekCloseT); peekCloseT = null; }
+  else if (!peekCloseT) peekCloseT = setTimeout(closeSidebarPeek, 300);
+}
+function bindSidebarPeek() {
+  const hot = $('#sidebar-hot'), sidebar = $('#sidebar'), app = $('#app');
+  if (!hot || !sidebar) return;
+  hot.addEventListener('mouseenter', () => {
+    // 收起瞬间指针若还停在左缘，侧栏消失后浏览器会补发一次 mouseenter 到热区，会把刚按 Esc / 刚点导航收掉的悬浮立刻再弹出来；刚收起的 200ms 内不理
+    if (Date.now() - peekClosedAt < 200) return;
+    peekOpenT = setTimeout(() => { app.classList.add('sidebar-peek'); document.addEventListener('mousemove', onPeekMove); }, 150);
+  });
+  hot.addEventListener('mouseleave', () => clearTimeout(peekOpenT));
+  // 导航类（切目录/收藏/agent 项目、搜索、Skills、定时任务）点击后立即收起；开关类（主题/合盖/用量等）留着
+  sidebar.addEventListener('click', (e) => {
+    if (!app.classList.contains('sidebar-peek')) return;
+    if (e.target.closest('#roots-list li, #favs-list li, #agent-projects-list li, #cmdk-trigger, #skills-entry, #cron-entry')) closeSidebarPeek();
+  });
+}
 // 预览尺寸随 dock 翻转：终端在右→预览在下方用高度，否则用宽度
 function applyPreviewSize() {
   const pv = $('#preview');
@@ -1171,6 +1199,7 @@ function setPreviewMax(on) {
 }
 function applyPreviewWidth() { applyPreviewSize(); } // 兼容旧调用名
 function toggleSidebar(force) {
+  closeSidebarPeek(); // ⌘B / 顶栏按钮触发的展开折叠，和悬浮态互斥，先收起悬浮再切
   // 关/开侧栏前记下终端占主区的比例（仅左右分栏时）：腾出/收回的宽度按比例分给「文件区+预览」和终端，
   // 而不是全甩给左侧文件区
   const panel = $('#terminal-panel');
@@ -3229,6 +3258,7 @@ function bindEvents() {
     const inInput = ['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName) || document.activeElement.isContentEditable || inTerm;
     // 输入框里按 Esc 先退出输入，别越级把预览关掉
     if (e.key === 'Escape' && inInput) { document.activeElement.blur(); return; }
+    if (e.key === 'Escape' && $('#app').classList.contains('sidebar-peek')) { e.preventDefault(); closeSidebarPeek(); return; }
     if (e.key === 'Escape' && !$('#preview').classList.contains('hidden')) { closePreview(); return; }
     if ((e.metaKey || e.ctrlKey) && e.key === '[') { e.preventDefault(); goBack(); return; }
     if ((e.metaKey || e.ctrlKey) && (e.key === 'b' || e.key === 'B') && !inInput) { e.preventDefault(); toggleSidebar(); return; }
@@ -6054,6 +6084,7 @@ async function init() {
   bindEvents();
   bindResizer();
   bindSidebarResizer();
+  bindSidebarPeek();
   bindSelectionToTerminal();
   enableTooltips();
   // md 里直接引用本地文件路径的图片，按页面 URL 解析必 404：加载失败时解析成绝对路径兜底显示。

--- a/public/index.html
+++ b/public/index.html
@@ -86,6 +86,9 @@
       <div id="sidebar-resizer" title="拖动调整侧栏宽度"></div>
     </aside>
 
+    <!-- 折叠态下窗口左缘的悬浮热区：悬停触发侧栏临时浮现，见 bindSidebarPeek -->
+    <div id="sidebar-hot"></div>
+
     <!-- 主区 -->
     <main id="main">
       <header id="topbar">

--- a/public/style.css
+++ b/public/style.css
@@ -99,6 +99,20 @@ body {
 /* 折叠后顶栏贴到窗口左缘，给 macOS 红绿灯让位 */
 #app.sidebar-collapsed #topbar { padding-left: 80px; }
 
+/* ---------- 悬浮：折叠态下窗口左缘的热区 + 临时浮现的侧栏 ---------- */
+/* 热区：折叠且未悬浮时才存在，悬浮期间侧栏自己盖住这块地方，不需要热区再响应 */
+#sidebar-hot { position: fixed; top: 0; bottom: 0; left: 0; width: 6px; z-index: 44; display: none; -webkit-app-region: no-drag; }
+#app.sidebar-collapsed:not(.sidebar-peek) #sidebar-hot { display: block; }
+/* 预览全屏 / 图片编辑全屏时关掉热区：这两种全屏本就盖住整个窗口，悬浮弹出来也看不见，纯增加误触 */
+.preview-maxed #sidebar-hot, #app:has(.imgedit-tools) #sidebar-hot { display: none !important; }
+/* 悬浮：不占栅格列（fixed 脱离文档流），覆盖在主区之上；实色背景盖过 .desktop 半透明毛玻璃 */
+#app.sidebar-collapsed.sidebar-peek > #sidebar {
+  display: flex; position: fixed; top: 0; bottom: 0; left: 0; width: var(--sidebar-w, 248px);
+  z-index: 45; background: var(--panel); box-shadow: var(--shadow);
+  animation: sidebarPeekIn 0.18s ease;
+}
+@keyframes sidebarPeekIn { from { transform: translateX(-100%); } }
+
 /* ---------- 侧边栏 ---------- */
 #sidebar {
   background: var(--panel);


### PR DESCRIPTION
## 做了什么

侧栏折叠后，鼠标停在窗口左缘 6px 热区 150ms，侧栏以覆盖层浮出；移开 300ms 后收起，移回取消。悬浮是折叠的临时子态：不写 localStorage，⌘B / 顶栏按钮语义不变，重启后仍是折叠。

- 覆盖层 fixed、z-index 45、实色背景、0.18s 滑入，主区栅格保持单列，不重排、不触发终端 fit
- Esc 收起；点目录 / 收藏 / agent 项目 / 搜索 / Skills / 定时任务这类导航项后立即收起；主题 / 合盖 / 用量等开关类操作不收
- ⌘B 和顶栏按钮在悬浮中先收悬浮再正常展开或折叠
- 预览全屏、图片编辑全屏期间热区禁用，避免看图时左缘误触
- 悬浮态不带拖宽条、不加固定按钮

## 两个实测踩到的坑

1. 侧栏是在指针静止时浮出来盖住指针的，浏览器不补发 mouseenter，之后指针一步甩到主区就收不到 mouseleave，悬浮会卡住。改为悬浮期间用全局 mousemove 判定指针是否在侧栏内。
2. 收起瞬间指针若还停在左缘，浏览器会补发一次 mouseenter 到热区（实测 keydown 后 1ms），把刚按 Esc 收掉的悬浮再弹出来。刚收起 200ms 内热区不响应。

## 验证

Chrome 152 + 真实指针移动 + 计时断言，控制台无 error / warn：

- 真实悬停左缘弹出，覆盖层 248px、fixed、z 45，主区栅格仍为单列
- 离开后 150ms 仍开，300ms 内移回取消，400ms 后收起
- Esc 收起且不反弹；点 Home 行立即收起；点主题按钮 / 用量展开不收
- `preview-maxed` 期间热区 display 为 none
- 悬浮中 `toggleSidebar()` 直接变干净展开态，再切回折叠正常

**未验证**：Electron 桌面版顶栏是 `-webkit-app-region: drag` 区，热区叠在最上面 ~40px 是否收得到鼠标事件没在 Electron 里跑过（热区元素已声明 `no-drag`）。收不到的话把热区改成从顶栏下沿开始即可。

